### PR TITLE
fix: datatime millis

### DIFF
--- a/ingester-protocol/src/main/java/io/greptime/models/Util.java
+++ b/ingester-protocol/src/main/java/io/greptime/models/Util.java
@@ -67,19 +67,17 @@ public class Util {
         return (int) getLongValue(value);
     }
 
-    static int getDateTimeValue(Object value) {
+    static long getDateTimeValue(Object value) {
         if (value instanceof Instant) {
-            long epochSecond = ((Instant) value).getEpochSecond();
-            return (int) epochSecond;
+            return ((Instant) value).toEpochMilli();
         }
 
         if (value instanceof Date) {
             Instant instant = ((Date) value).toInstant();
-            long epochSecond = instant.getEpochSecond();
-            return (int) epochSecond;
+            return instant.toEpochMilli();
         }
 
-        return (int) getLongValue(value);
+        return getLongValue(value);
     }
 
     static Common.IntervalMonthDayNano getIntervalMonthDayNanoValue(Object value) {

--- a/ingester-protocol/src/test/java/io/greptime/models/UtilTest.java
+++ b/ingester-protocol/src/test/java/io/greptime/models/UtilTest.java
@@ -60,8 +60,10 @@ public class UtilTest {
         TimeZone gmtTimeZone = TimeZone.getTimeZone("GMT");
         cal.setTimeZone(gmtTimeZone);
         cal.set(1970, Calendar.JANUARY, 2, 0, 0, 0);
-        Assert.assertEquals(86400, Util.getDateTimeValue(cal.getTime()));
-        Assert.assertEquals(86400, Util.getDateTimeValue(Instant.ofEpochSecond(86400)));
+        cal.set(Calendar.MILLISECOND, 111);
+        Assert.assertEquals(86400111, Util.getDateTimeValue(cal.getTime()));
+        Assert.assertEquals(86400111, Util.getDateTimeValue(cal.getTime().toInstant()));
+        Assert.assertEquals(86400000, Util.getDateTimeValue(Instant.ofEpochSecond(86400)));
         Assert.assertEquals(86400, Util.getDateTimeValue(86400));
     }
 


### PR DESCRIPTION
Because the db change the `DateTime` from [seconds to millis](https://github.com/GreptimeTeam/greptimedb/commit/54e506a4940d01ffd3f2e44e450ab6e8cca35481#diff-2f52fff389d90de1f91c0d66b9c7d9e6a48d25beb2c1dfb9ee6dcff2aba4d245L27)