### PR TITLE
feat: add option to connect to secure grpc port

### DIFF
--- a/ingester-example/src/main/java/io/greptime/TestConnector.java
+++ b/ingester-example/src/main/java/io/greptime/TestConnector.java
@@ -85,6 +85,8 @@ public class TestConnector {
                 .router(null)
                 // Sets authentication information. If the DB is not required to authenticate, we can ignore this.
                 .authInfo(AuthInfo.noAuthorization())
+                // Enable TLS connection when remote port is secured by TLS
+                // .tlsOptions(new TlsOptions())
                 // A good start ^_^
                 .build();
 

--- a/ingester-grpc/src/main/java/io/greptime/rpc/GrpcClient.java
+++ b/ingester-grpc/src/main/java/io/greptime/rpc/GrpcClient.java
@@ -573,10 +573,10 @@ public class GrpcClient implements RpcClient {
         NettyChannelBuilder innerChannelBuilder =
                 NettyChannelBuilder.forAddress(endpoint.getAddr(), endpoint.getPort());
 
-        if (this.opts.getTlsOptions().isEmpty()) {
-            innerChannelBuilder.usePlaintext();
-        } else {
+        if (this.opts.getTlsOptions().isPresent()) {
             innerChannelBuilder.useTransportSecurity().sslContext(newSslContext(this.opts.getTlsOptions().get()));
+        } else {
+            innerChannelBuilder.usePlaintext();
         }
 
         ManagedChannel innerChannel = innerChannelBuilder.executor(this.asyncPool) //

--- a/ingester-grpc/src/main/java/io/greptime/rpc/GrpcClient.java
+++ b/ingester-grpc/src/main/java/io/greptime/rpc/GrpcClient.java
@@ -48,6 +48,7 @@ import io.grpc.ClientInterceptor;
 import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.shaded.io.netty.channel.ChannelOption;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
@@ -548,7 +549,7 @@ public class GrpcClient implements RpcClient {
     private SslContext newSslContext(TlsOptions tlsOptions) {
 
         try {
-            SslContextBuilder builder = SslContextBuilder.forClient();
+            SslContextBuilder builder = GrpcSslContexts.forClient();
 
             if (tlsOptions.getClientCertChain().isPresent() && tlsOptions.getPrivateKey().isPresent()) {
                 if (tlsOptions.getPrivateKeyPassword().isPresent()) {

--- a/ingester-grpc/src/main/java/io/greptime/rpc/GrpcClient.java
+++ b/ingester-grpc/src/main/java/io/greptime/rpc/GrpcClient.java
@@ -552,10 +552,10 @@ public class GrpcClient implements RpcClient {
 
             if (tlsOptions.getClientCertChain().isPresent() && tlsOptions.getPrivateKey().isPresent()) {
                 if (tlsOptions.getPrivateKeyPassword().isPresent()) {
-                    builder.keyManager(tlsOptions.getClientCertChain().get(), tlsOptions.getPrivateKey().get());
-                } else {
                     builder.keyManager(tlsOptions.getClientCertChain().get(), tlsOptions.getPrivateKey().get(),
                             tlsOptions.getPrivateKeyPassword().get());
+                } else {
+                    builder.keyManager(tlsOptions.getClientCertChain().get(), tlsOptions.getPrivateKey().get());
                 }
             }
 

--- a/ingester-protocol/src/main/java/io/greptime/options/GreptimeOptions.java
+++ b/ingester-protocol/src/main/java/io/greptime/options/GreptimeOptions.java
@@ -22,6 +22,7 @@ import io.greptime.common.util.Ensures;
 import io.greptime.limit.LimitedPolicy;
 import io.greptime.models.AuthInfo;
 import io.greptime.rpc.RpcOptions;
+import io.greptime.rpc.TlsOptions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -276,6 +277,18 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
          */
         public Builder router(Router<Void, Endpoint> router) {
             this.router = router;
+            return this;
+        }
+
+        /**
+         * Set `TlsOptions` to use secure connection between client and server. Set to `null` to use
+         * plaintext connection instead.
+         *
+         * @param tlsOptions for configure secure connection, set to null to use plaintext
+         * @return this builder
+         */
+        public Builder tlsOptions(TlsOptions tlsOptions) {
+            this.rpcOptions.setTlsOptions(tlsOptions);
             return this;
         }
 

--- a/ingester-rpc/src/main/java/io/greptime/rpc/RpcOptions.java
+++ b/ingester-rpc/src/main/java/io/greptime/rpc/RpcOptions.java
@@ -262,6 +262,7 @@ public class RpcOptions implements Copiable<RpcOptions> {
         opts.blockOnLimit = this.blockOnLimit;
         opts.logOnLimitChange = this.logOnLimitChange;
         opts.enableMetricInterceptor = this.enableMetricInterceptor;
+        opts.tlsOptions = this.tlsOptions;
         return opts;
     }
 

--- a/ingester-rpc/src/main/java/io/greptime/rpc/RpcOptions.java
+++ b/ingester-rpc/src/main/java/io/greptime/rpc/RpcOptions.java
@@ -16,6 +16,7 @@
 package io.greptime.rpc;
 
 import io.greptime.common.Copiable;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -99,6 +100,20 @@ public class RpcOptions implements Copiable<RpcOptions> {
     private boolean logOnLimitChange = true;
 
     private boolean enableMetricInterceptor = false;
+
+    /**
+     * Set `TlsOptions` to use secure connection between client and server. Set to `null` to use
+     * plaintext connection instead.
+     */
+    private Optional<TlsOptions> tlsOptions = Optional.empty();
+
+    public Optional<TlsOptions> getTlsOptions() {
+        return tlsOptions;
+    }
+
+    public void setTlsOptions(TlsOptions tlsOptions) {
+        this.tlsOptions = Optional.ofNullable(tlsOptions);
+    }
 
     public boolean isUseRpcSharedPool() {
         return useRpcSharedPool;
@@ -269,6 +284,7 @@ public class RpcOptions implements Copiable<RpcOptions> {
                 ", blockOnLimit=" + blockOnLimit + //
                 ", logOnLimitChange=" + logOnLimitChange + //
                 ", enableMetricInterceptor=" + enableMetricInterceptor + //
+                ", tlsOptions=" + tlsOptions + //
                 '}';
     }
 

--- a/ingester-rpc/src/main/java/io/greptime/rpc/TlsOptions.java
+++ b/ingester-rpc/src/main/java/io/greptime/rpc/TlsOptions.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.greptime.rpc;
+
+import io.greptime.common.Copiable;
+import java.io.File;
+import java.util.Optional;
+
+/**
+ * GreptimeDB secure connection options
+ *
+ * @author Ning Sun<sunning@greptime.com>
+ */
+public class TlsOptions implements Copiable<TlsOptions> {
+
+    private Optional<File> clientCertChain;
+
+    private Optional<File> privateKey;
+
+    private Optional<String> privateKeyPassword;
+
+    private Optional<File> rootCerts;
+
+    @Override
+    public TlsOptions copy() {
+        TlsOptions that = new TlsOptions();
+
+        that.setClientCertChain(this.getClientCertChain());
+        that.setPrivateKey(this.getPrivateKey());
+        that.setPrivateKeyPassword(this.getPrivateKeyPassword());
+        that.setRootCerts(this.getRootCerts());
+
+        return that;
+    }
+
+    public Optional<File> getClientCertChain() {
+        return clientCertChain;
+    }
+
+    public void setClientCertChain(Optional<File> clientCertChain) {
+        this.clientCertChain = clientCertChain;
+    }
+
+    public Optional<File> getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(Optional<File> privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    public Optional<String> getPrivateKeyPassword() {
+        return privateKeyPassword;
+    }
+
+    public void setPrivateKeyPassword(Optional<String> privateKeyPassword) {
+        this.privateKeyPassword = privateKeyPassword;
+    }
+
+    public Optional<File> getRootCerts() {
+        return rootCerts;
+    }
+
+    public void setRootCerts(Optional<File> rootCerts) {
+        this.rootCerts = rootCerts;
+    }
+
+    @Override
+    public String toString() {
+        return "TlsOptions{"
+                + //
+                "clientCertChain="
+                + this.clientCertChain
+                + //
+                ", privateKey="
+                + this.privateKey
+                + //
+                ", privateKeyPassword="
+                + this.privateKeyPassword.map((v) -> "****")
+                + //
+                ", rootCerts="
+                + this.rootCerts
+                + '}';
+    }
+}

--- a/ingester-rpc/src/main/java/io/greptime/rpc/TlsOptions.java
+++ b/ingester-rpc/src/main/java/io/greptime/rpc/TlsOptions.java
@@ -26,13 +26,13 @@ import java.util.Optional;
  */
 public class TlsOptions implements Copiable<TlsOptions> {
 
-    private Optional<File> clientCertChain;
+    private Optional<File> clientCertChain = Optional.empty();
 
-    private Optional<File> privateKey;
+    private Optional<File> privateKey = Optional.empty();
 
-    private Optional<String> privateKeyPassword;
+    private Optional<String> privateKeyPassword = Optional.empty();
 
-    private Optional<File> rootCerts;
+    private Optional<File> rootCerts = Optional.empty();
 
     @Override
     public TlsOptions copy() {


### PR DESCRIPTION
this patch add `TlsOption` that allows user to connect to a tls protected grpc port.

This option can be configured via `GreptimeOption` builder. It also contains optional certficate and trust root when the server hosts self-signed certificate.