### PR TITLE
feat: remove interval type and give datetime an alias

### DIFF
--- a/ingester-protocol/src/main/java/io/greptime/models/DataType.java
+++ b/ingester-protocol/src/main/java/io/greptime/models/DataType.java
@@ -37,6 +37,7 @@ public enum DataType {
     Binary,
     String,
     Date,
+    @Deprecated
     DateTime,
     TimestampSecond,
     TimestampMillisecond,
@@ -46,9 +47,6 @@ public enum DataType {
     TimeMilliSecond,
     TimeMicroSecond,
     TimeNanoSecond,
-    IntervalYearMonth,
-    IntervalDayTime,
-    IntervalMonthDayNano,
     Decimal128,
     Json,
     ;
@@ -90,12 +88,13 @@ public enum DataType {
                 return Common.ColumnDataType.STRING;
             case Date:
                 return Common.ColumnDataType.DATE;
-            case DateTime:
-                return Common.ColumnDataType.DATETIME;
             case TimestampSecond:
                 return Common.ColumnDataType.TIMESTAMP_SECOND;
             case TimestampMillisecond:
                 return Common.ColumnDataType.TIMESTAMP_MILLISECOND;
+            case DateTime:
+                // DateTime is an alias of TIMESTAMP_MICROSECOND
+                // https://github.com/GreptimeTeam/greptimedb/issues/5489
             case TimestampMicrosecond:
                 return Common.ColumnDataType.TIMESTAMP_MICROSECOND;
             case TimestampNanosecond:
@@ -108,12 +107,6 @@ public enum DataType {
                 return Common.ColumnDataType.TIME_MICROSECOND;
             case TimeNanoSecond:
                 return Common.ColumnDataType.TIME_NANOSECOND;
-            case IntervalYearMonth:
-                return Common.ColumnDataType.INTERVAL_YEAR_MONTH;
-            case IntervalDayTime:
-                return Common.ColumnDataType.INTERVAL_DAY_TIME;
-            case IntervalMonthDayNano:
-                return Common.ColumnDataType.INTERVAL_MONTH_DAY_NANO;
             case Decimal128:
                 return Common.ColumnDataType.DECIMAL128;
             case Json:

--- a/ingester-protocol/src/main/java/io/greptime/models/RowHelper.java
+++ b/ingester-protocol/src/main/java/io/greptime/models/RowHelper.java
@@ -19,6 +19,7 @@ package io.greptime.models;
 import com.google.protobuf.UnsafeByteOperations;
 import io.greptime.v1.Common;
 import io.greptime.v1.RowData;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A utility that handles some processing of row based data.
@@ -79,20 +80,17 @@ public final class RowHelper {
             case DATE:
                 valueBuilder.setDateValue(ValueUtil.getDateValue(value));
                 break;
-            case DATETIME:
-                valueBuilder.setDatetimeValue(ValueUtil.getDateTimeValue(value));
-                break;
             case TIMESTAMP_SECOND:
-                valueBuilder.setTimestampSecondValue(ValueUtil.getLongValue(value));
+                valueBuilder.setTimestampSecondValue(ValueUtil.getTimestamp(value, TimeUnit.SECONDS));
                 break;
             case TIMESTAMP_MILLISECOND:
-                valueBuilder.setTimestampMillisecondValue(ValueUtil.getLongValue(value));
+                valueBuilder.setTimestampMillisecondValue(ValueUtil.getTimestamp(value, TimeUnit.MILLISECONDS));
                 break;
             case TIMESTAMP_MICROSECOND:
-                valueBuilder.setTimestampMicrosecondValue(ValueUtil.getLongValue(value));
+                valueBuilder.setTimestampMicrosecondValue(ValueUtil.getTimestamp(value, TimeUnit.MICROSECONDS));
                 break;
             case TIMESTAMP_NANOSECOND:
-                valueBuilder.setTimestampNanosecondValue(ValueUtil.getLongValue(value));
+                valueBuilder.setTimestampNanosecondValue(ValueUtil.getTimestamp(value, TimeUnit.NANOSECONDS));
                 break;
             case TIME_SECOND:
                 valueBuilder.setTimeSecondValue(ValueUtil.getLongValue(value));
@@ -105,15 +103,6 @@ public final class RowHelper {
                 break;
             case TIME_NANOSECOND:
                 valueBuilder.setTimeNanosecondValue(ValueUtil.getLongValue(value));
-                break;
-            case INTERVAL_YEAR_MONTH:
-                valueBuilder.setIntervalYearMonthValue((int) value);
-                break;
-            case INTERVAL_DAY_TIME:
-                valueBuilder.setIntervalDayTimeValue(ValueUtil.getLongValue(value));
-                break;
-            case INTERVAL_MONTH_DAY_NANO:
-                valueBuilder.setIntervalMonthDayNanoValue(ValueUtil.getIntervalMonthDayNanoValue(value));
                 break;
             case DECIMAL128:
                 valueBuilder.setDecimal128Value(ValueUtil.getDecimal128Value(dataTypeExtension, value));

--- a/ingester-protocol/src/test/java/io/greptime/WriteClientTest.java
+++ b/ingester-protocol/src/test/java/io/greptime/WriteClientTest.java
@@ -19,7 +19,6 @@ package io.greptime;
 import io.greptime.common.Endpoint;
 import io.greptime.models.DataType;
 import io.greptime.models.Err;
-import io.greptime.models.IntervalMonthDayNano;
 import io.greptime.models.Result;
 import io.greptime.models.Table;
 import io.greptime.models.TableSchema;
@@ -69,6 +68,7 @@ public class WriteClientTest {
 
     @Test
     public void testWriteSuccess() throws ExecutionException, InterruptedException {
+        @SuppressWarnings("deprecation")
         TableSchema schema = TableSchema.newBuilder("test_table")
                 .addTag("test_tag", DataType.String)
                 .addTimestamp("test_ts", DataType.TimestampMillisecond)
@@ -94,9 +94,6 @@ public class WriteClientTest {
                 .addField("field20", DataType.TimeMilliSecond)
                 .addField("field21", DataType.TimeMicroSecond)
                 .addField("field22", DataType.TimeNanoSecond)
-                .addField("field23", DataType.IntervalYearMonth)
-                .addField("field24", DataType.IntervalDayTime)
-                .addField("field25", DataType.IntervalMonthDayNano)
                 .addField("field26", DataType.Decimal128)
                 .addField("field27", DataType.Json)
                 .build();
@@ -104,12 +101,12 @@ public class WriteClientTest {
         long ts = System.currentTimeMillis();
 
         // spotless:off
-        Object[] row1 = new Object[]{"tag1", ts, 1, 2, 3, 4L, 5, 6, 7, 8L, 0.9F, 0.10D, true, new byte[0], 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23, 24L, new IntervalMonthDayNano(1, 2, 3), BigDecimal.valueOf(123.456), "{\"a\": 1}"};
-        Object[] row2 = new Object[]{"tag2", ts, 1, 2, 3, 4L, 5, 6, 7, 8L, 0.9F, 0.10D, true, new byte[0], 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23, 24L, new IntervalMonthDayNano(4, 5, 6), BigDecimal.valueOf(123.456), "{\"b\": 2}"};
+        Object[] row1 = new Object[]{"tag1", ts, 1, 2, 3, 4L, 5, 6, 7, 8L, 0.9F, 0.10D, true, new byte[0], 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, BigDecimal.valueOf(123.456), "{\"a\": 1}"};
+        Object[] row2 = new Object[]{"tag2", ts, 1, 2, 3, 4L, 5, 6, 7, 8L, 0.9F, 0.10D, true, new byte[0], 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, BigDecimal.valueOf(123.456), "{\"b\": 2}"};
         Map<String, Object> json = new HashMap<>();
         json.put("name", "test");
         json.put("value", 123);
-        Object[] row3 = new Object[]{"tag3", ts, 1, 2, 3, 4L, 5, 6, 7, 8L, 0.9F, 0.10D, true, new byte[0], 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23, 24L, new IntervalMonthDayNano(7, 8, 9), BigDecimal.valueOf(123.456), json};
+        Object[] row3 = new Object[]{"tag3", ts, 1, 2, 3, 4L, 5, 6, 7, 8L, 0.9F, 0.10D, true, new byte[0], 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, BigDecimal.valueOf(123.456), json};
         // spotless:on
 
         table.addRow(row1);


### PR DESCRIPTION
1. Remove all `Interval` data types; for details, see https://github.com/GreptimeTeam/greptimedb/issues/5489.
2. Make `DateTime` an alias of timestamp(6); for details, see https://github.com/GreptimeTeam/greptimedb/pull/5422.
3. Minor user experience improvement: allow direct use of the Instant type to write into the Timestamp column.