### PR TITLE
chore: context minor refactor

### DIFF
--- a/ingester-rpc/src/main/java/io/greptime/rpc/Context.java
+++ b/ingester-rpc/src/main/java/io/greptime/rpc/Context.java
@@ -16,7 +16,6 @@
 
 package io.greptime.rpc;
 
-import io.greptime.common.Copiable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -26,7 +25,7 @@ import java.util.Set;
  * database server in the form of KV.
  */
 @SuppressWarnings({"unchecked"})
-public class Context implements Copiable<Context> {
+public class Context {
 
     private static final String HINTS_KEY = "x-greptime-hints";
 
@@ -168,6 +167,7 @@ public class Context implements Copiable<Context> {
     public void clear() {
         synchronized (this) {
             this.ctx.clear();
+            this.compression = Compression.None;
         }
     }
 
@@ -183,16 +183,7 @@ public class Context implements Copiable<Context> {
     @Override
     public String toString() {
         synchronized (this) {
-            return this.ctx.toString();
-        }
-    }
-
-    @Override
-    public Context copy() {
-        synchronized (this) {
-            Context copy = new Context();
-            copy.ctx.putAll(this.ctx);
-            return copy;
+            return "Context{" + "ctx=" + ctx + ", compression=" + compression + '}';
         }
     }
 }

--- a/ingester-rpc/src/test/java/io/greptime/rpc/ContextTest.java
+++ b/ingester-rpc/src/test/java/io/greptime/rpc/ContextTest.java
@@ -76,12 +76,6 @@ public class ContextTest {
         Context context = Context.of("key", "value");
         context.clear();
         Assert.assertTrue(context.entrySet().isEmpty());
-    }
-
-    @Test
-    public void copyShouldReturnIdenticalContextTest() {
-        Context context = Context.of("key", "value");
-        Context copy = context.copy();
-        Assert.assertEquals(context.get("key").toString(), copy.get("key").toString());
+        Assert.assertEquals(Compression.None, context.getCompression());
     }
 }


### PR DESCRIPTION
1. remove unnecessary `Copiable` trait impl
2. forgot to clear Compression field
3. toString forgot Compression field