### PR TITLE
chore: default rpc timeout to 60s

### DIFF
--- a/ingester-rpc/src/main/java/io/greptime/rpc/RpcOptions.java
+++ b/ingester-rpc/src/main/java/io/greptime/rpc/RpcOptions.java
@@ -28,9 +28,9 @@ public class RpcOptions implements Copiable<RpcOptions> {
 
     /**
      * RPC request default timeout in milliseconds
-     * Default: 10000(10s)
+     * Default: 60000(60s)
      */
-    private int defaultRpcTimeout = 10000;
+    private int defaultRpcTimeout = 60000;
 
     /**
      * Sets the maximum message size allowed to be received on a channel.


### PR DESCRIPTION
Sometimes users write very large amounts of data, causing the response to slow down.
