### PR TITLE
feat: enable gRPC keepalive by default

### DIFF
--- a/docs/GreptimeOptions-Configuration-Guide.md
+++ b/docs/GreptimeOptions-Configuration-Guide.md
@@ -59,19 +59,20 @@ GreptimeOptions options = GreptimeOptions.newBuilder(
 
 ### 3. RPC Configuration
 
-The following configurations only apply to Regular API, not to Bulk API
-
 #### rpcOptions (RPC Options)
 - **Type**: `RpcOptions`
 - **Default**: `RpcOptions.newDefault()`
 - **Description**: RPC connection related configuration
+- **API Scope**:
+  - The channel-related settings `maxInboundMessageSize`, `flowControlWindow`, `idleTimeoutSeconds`, `keepAliveTimeSeconds`, `keepAliveTimeoutSeconds`, and `keepAliveWithoutCalls` apply to both Regular API and Bulk API
+  - `useRpcSharedPool`, `defaultRpcTimeout`, all limiter settings, and `enableMetricInterceptor` apply only to Regular API
 - **Key Parameters**:
   - `useRpcSharedPool`: Whether to use global RPC shared pool, default false. By default, only gRPC internal IO threads are used to handle all tasks. It's recommended to start with the default value for your application
   - `defaultRpcTimeout`: RPC request timeout, default 60000ms (60 seconds)
   - `maxInboundMessageSize`: Maximum inbound message size, default 256MB
   - `flowControlWindow`: Flow control window size, default 256MB
   - `idleTimeoutSeconds`: Idle timeout duration, default 5 minutes
-  - `keepAliveTimeSeconds`: Time without read activity before sending keep-alive ping, default Long.MAX_VALUE (disabled)
+  - `keepAliveTimeSeconds`: Time without read activity before sending keep-alive ping, default 60 seconds
   - `keepAliveTimeoutSeconds`: Time waiting for read activity after keep-alive ping, default 3 seconds
   - `keepAliveWithoutCalls`: Whether to perform keep-alive when no outstanding RPC, default false
   - `limitKind`: gRPC layer concurrency limit algorithm, default None. Not recommended to enable without special requirements, suggest using SDK upper-layer flow control mechanisms (continue reading this document, mentioned below)
@@ -89,17 +90,19 @@ The following configurations only apply to Regular API, not to Bulk API
 
 **Example**:
 ```java
-RpcOptions rpcOpts = RpcOptions.newDefault()
-    .setDefaultRpcTimeout(30000)  // 30 seconds timeout
-    .setMaxInboundMessageSize(128 * 1024 * 1024)  // 128MB
-    .setKeepAliveTimeSeconds(30)  // Enable keep-alive every 30 seconds
-    .setKeepAliveTimeoutSeconds(5)  // 5 seconds keep-alive timeout
-    .setKeepAliveWithoutCalls(true)  // Keep-alive even without calls
-    .setLimitKind(RpcOptions.LimitKind.Vegas)  // Use Vegas flow limiter
-    .setInitialLimit(32)  // Start with 32 concurrent requests
-    .setMaxLimit(512);  // Max 512 concurrent requests
-    
-.rpcOptions(rpcOpts)
+RpcOptions rpcOpts = RpcOptions.newDefault();
+rpcOpts.setDefaultRpcTimeout(30000);  // 30 seconds timeout
+rpcOpts.setMaxInboundMessageSize(128 * 1024 * 1024);  // 128MB
+rpcOpts.setKeepAliveTimeSeconds(30);  // Send keep-alive after 30 seconds without reads
+rpcOpts.setKeepAliveTimeoutSeconds(5);  // 5 seconds keep-alive timeout
+rpcOpts.setKeepAliveWithoutCalls(true);  // Keep alive even without calls
+rpcOpts.setLimitKind(RpcOptions.LimitKind.Vegas);  // Use Vegas flow limiter
+rpcOpts.setInitialLimit(32);  // Start with 32 concurrent requests
+rpcOpts.setMaxLimit(512);  // Max 512 concurrent requests
+
+GreptimeOptions options = GreptimeOptions.newBuilder("127.0.0.1:4001", "public")
+    .rpcOptions(rpcOpts)
+    .build();
 ```
 
 ### 4. TLS Security Configuration
@@ -107,7 +110,7 @@ RpcOptions rpcOpts = RpcOptions.newDefault()
 #### tlsOptions (TLS Options)
 - **Type**: `TlsOptions`
 - **Default**: null (uses plaintext connection)
-- **Description**: Enable secure connection between client and server
+- **Description**: Enable secure connections for both Regular API and Bulk API
 - **Key Parameters**:
   - `clientCertChain`: Client certificate chain file
   - `privateKey`: Private key file
@@ -231,4 +234,3 @@ AuthInfo auth = new AuthInfo("username", "password");
 ```java
 .router(customRouter)
 ```
-

--- a/docs/GreptimeOptions-Configuration-Guide.md
+++ b/docs/GreptimeOptions-Configuration-Guide.md
@@ -93,9 +93,9 @@ GreptimeOptions options = GreptimeOptions.newBuilder(
 RpcOptions rpcOpts = RpcOptions.newDefault();
 rpcOpts.setDefaultRpcTimeout(30000);  // 30 seconds timeout
 rpcOpts.setMaxInboundMessageSize(128 * 1024 * 1024);  // 128MB
-rpcOpts.setKeepAliveTimeSeconds(30);  // Send keep-alive after 30 seconds without reads
+rpcOpts.setKeepAliveTimeSeconds(60);  // Use shorter intervals only with server-owner approval
 rpcOpts.setKeepAliveTimeoutSeconds(5);  // 5 seconds keep-alive timeout
-rpcOpts.setKeepAliveWithoutCalls(true);  // Keep alive even without calls
+rpcOpts.setKeepAliveWithoutCalls(false);  // Enable idle keep-alive only with server-owner approval
 rpcOpts.setLimitKind(RpcOptions.LimitKind.Vegas);  // Use Vegas flow limiter
 rpcOpts.setInitialLimit(32);  // Start with 32 concurrent requests
 rpcOpts.setMaxLimit(512);  // Max 512 concurrent requests

--- a/docs/GreptimeOptions-配置指南.md
+++ b/docs/GreptimeOptions-配置指南.md
@@ -93,9 +93,9 @@ GreptimeOptions options = GreptimeOptions.newBuilder(
 RpcOptions rpcOpts = RpcOptions.newDefault();
 rpcOpts.setDefaultRpcTimeout(30000);  // 30 秒超时
 rpcOpts.setMaxInboundMessageSize(128 * 1024 * 1024);  // 128 MB
-rpcOpts.setKeepAliveTimeSeconds(30);  // 无读取活动 30 秒后发送保活 ping
+rpcOpts.setKeepAliveTimeSeconds(60);  // 仅在服务端负责人允许时使用更短间隔
 rpcOpts.setKeepAliveTimeoutSeconds(5);  // 5 秒保活超时
-rpcOpts.setKeepAliveWithoutCalls(true);  // 即使没有调用也保活
+rpcOpts.setKeepAliveWithoutCalls(false);  // 仅在服务端负责人允许时启用空闲保活
 rpcOpts.setLimitKind(RpcOptions.LimitKind.Vegas);  // 使用 Vegas 限流器
 rpcOpts.setInitialLimit(32);  // 从 32 个并发请求开始
 rpcOpts.setMaxLimit(512);  // 最大 512 个并发请求

--- a/docs/GreptimeOptions-配置指南.md
+++ b/docs/GreptimeOptions-配置指南.md
@@ -59,19 +59,20 @@ GreptimeOptions options = GreptimeOptions.newBuilder(
 
 ### 3. RPC 配置
 
-以下配置只针对 Regular API，不对 Bulk API 生效
-
 #### rpcOptions (RPC 选项)
 - **类型**: `RpcOptions`
 - **默认值**: `RpcOptions.newDefault()`
 - **描述**: RPC 连接相关配置
+- **API 适用范围**:
+  - 通道相关设置 `maxInboundMessageSize`、`flowControlWindow`、`idleTimeoutSeconds`、`keepAliveTimeSeconds`、`keepAliveTimeoutSeconds` 和 `keepAliveWithoutCalls` 对 Regular API 和 Bulk API 均生效
+  - `useRpcSharedPool`、`defaultRpcTimeout`、所有限流器设置和 `enableMetricInterceptor` 仅对 Regular API 生效
 - **主要参数**:
   - `useRpcSharedPool`: 是否使用全局 RPC 共享池，默认 false，即默认只使用 gRPC 内部的 IO 线程来处理所有任务，建议从默认值开始你的应用
   - `defaultRpcTimeout`: RPC 请求超时时间，默认 60000ms（60 秒）
   - `maxInboundMessageSize`: 最大入站消息大小，默认 256 MB
   - `flowControlWindow`: 流控窗口大小，默认 256 MB
   - `idleTimeoutSeconds`: 空闲超时时间，默认 5 分钟
-  - `keepAliveTimeSeconds`: 发送保活 ping 前的无读取活动时间，默认 Long.MAX_VALUE（禁用）
+  - `keepAliveTimeSeconds`: 发送保活 ping 前的无读取活动时间，默认 60 秒
   - `keepAliveTimeoutSeconds`: 保活 ping 后等待读取活动的时间，默认 3 秒
   - `keepAliveWithoutCalls`: 无未完成 RPC 时是否执行保活，默认 false
   - `limitKind`: gRPC 层的并发限制算法，默认 None，没有特殊需求不建议开启，建议使用 SDK 上层的限流机制（可继续阅读该文档，下面会提到）
@@ -89,17 +90,19 @@ GreptimeOptions options = GreptimeOptions.newBuilder(
 
 **示例**:
 ```java
-RpcOptions rpcOpts = RpcOptions.newDefault()
-    .setDefaultRpcTimeout(30000)  // 30 秒超时
-    .setMaxInboundMessageSize(128 * 1024 * 1024)  // 128 MB
-    .setKeepAliveTimeSeconds(30)  // 每 30 秒启用保活
-    .setKeepAliveTimeoutSeconds(5)  // 5 秒保活超时
-    .setKeepAliveWithoutCalls(true)  // 即使没有调用也保活
-    .setLimitKind(RpcOptions.LimitKind.Vegas)  // 使用 Vegas 限流器
-    .setInitialLimit(32)  // 从 32 个并发请求开始
-    .setMaxLimit(512);  // 最大 512 个并发请求
-    
-.rpcOptions(rpcOpts)
+RpcOptions rpcOpts = RpcOptions.newDefault();
+rpcOpts.setDefaultRpcTimeout(30000);  // 30 秒超时
+rpcOpts.setMaxInboundMessageSize(128 * 1024 * 1024);  // 128 MB
+rpcOpts.setKeepAliveTimeSeconds(30);  // 无读取活动 30 秒后发送保活 ping
+rpcOpts.setKeepAliveTimeoutSeconds(5);  // 5 秒保活超时
+rpcOpts.setKeepAliveWithoutCalls(true);  // 即使没有调用也保活
+rpcOpts.setLimitKind(RpcOptions.LimitKind.Vegas);  // 使用 Vegas 限流器
+rpcOpts.setInitialLimit(32);  // 从 32 个并发请求开始
+rpcOpts.setMaxLimit(512);  // 最大 512 个并发请求
+
+GreptimeOptions options = GreptimeOptions.newBuilder("127.0.0.1:4001", "public")
+    .rpcOptions(rpcOpts)
+    .build();
 ```
 
 ### 4. TLS 安全配置
@@ -107,7 +110,7 @@ RpcOptions rpcOpts = RpcOptions.newDefault()
 #### tlsOptions (TLS 选项)
 - **类型**: `TlsOptions`
 - **默认值**: null (使用明文连接)
-- **描述**: 启用客户端和服务器之间的安全连接
+- **描述**: 为 Regular API 和 Bulk API 启用客户端和服务器之间的安全连接
 - **主要参数**:
   - `clientCertChain`: 客户端证书链文件
   - `privateKey`: 私钥文件

--- a/docs/metrics-display.md
+++ b/docs/metrics-display.md
@@ -61,14 +61,14 @@ id=1
 version=0.14.3
 endpoints=[127.0.0.1:4001]
 database=public
-rpcOptions=RpcOptions{useRpcSharedPool=false, defaultRpcTimeout=10000, maxInboundMessageSize=268435456, flowControlWindow=268435456, idleTimeoutSeconds=300, keepAliveTimeSeconds=9223372036854775807, keepAliveTimeoutSeconds=3, keepAliveWithoutCalls=false, limitKind=None, initialLimit=64, maxLimit=1024, longRttWindow=100, smoothing=0.2, blockOnLimit=false, logOnLimitChange=true, enableMetricInterceptor=false, tlsOptions=null}
+rpcOptions=RpcOptions{useRpcSharedPool=false, defaultRpcTimeout=10000, maxInboundMessageSize=268435456, flowControlWindow=268435456, idleTimeoutSeconds=300, keepAliveTimeSeconds=60, keepAliveTimeoutSeconds=3, keepAliveWithoutCalls=false, limitKind=None, initialLimit=64, maxLimit=1024, longRttWindow=100, smoothing=0.2, blockOnLimit=false, logOnLimitChange=true, enableMetricInterceptor=false, tlsOptions=null}
 
 --- RouterClient ---
 opts=RouterOptions{rpcClient=io.greptime.rpc.GrpcClient@55b699ef, endpoints=[127.0.0.1:4001], refreshPeriodSeconds=600, checkHealthTimeoutMs=1000, router=null}
 
 --- GrpcClient ---
 started=true
-opts=RpcOptions{useRpcSharedPool=false, defaultRpcTimeout=10000, maxInboundMessageSize=268435456, flowControlWindow=268435456, idleTimeoutSeconds=300, keepAliveTimeSeconds=9223372036854775807, keepAliveTimeoutSeconds=3, keepAliveWithoutCalls=false, limitKind=None, initialLimit=64, maxLimit=1024, longRttWindow=100, smoothing=0.2, blockOnLimit=false, logOnLimitChange=true, enableMetricInterceptor=false, tlsOptions=null}
+opts=RpcOptions{useRpcSharedPool=false, defaultRpcTimeout=10000, maxInboundMessageSize=268435456, flowControlWindow=268435456, idleTimeoutSeconds=300, keepAliveTimeSeconds=60, keepAliveTimeoutSeconds=3, keepAliveWithoutCalls=false, limitKind=None, initialLimit=64, maxLimit=1024, longRttWindow=100, smoothing=0.2, blockOnLimit=false, logOnLimitChange=true, enableMetricInterceptor=false, tlsOptions=null}
 connectionObservers=[io.greptime.GreptimeDB$RpcConnectionObserver@625d44db]
 asyncPool=DirectExecutor{name='rpc_direct_pool'}
 interceptors=[io.greptime.rpc.interceptors.ContextToHeadersInterceptor@275fd6f4]

--- a/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteManager.java
+++ b/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteManager.java
@@ -21,6 +21,7 @@ import io.greptime.common.Endpoint;
 import io.greptime.common.Keys;
 import io.greptime.common.util.Ensures;
 import io.greptime.common.util.MetricsUtil;
+import io.greptime.rpc.RpcOptions;
 import io.greptime.rpc.TlsOptions;
 import io.netty.util.internal.SystemPropertyUtil;
 import org.apache.arrow.flight.BulkFlightClient;
@@ -105,28 +106,89 @@ public class BulkWriteManager implements AutoCloseable {
             long allocatorMaxAllocation,
             ArrowCompressionType compressionType,
             TlsOptions tlsOptions) {
+        RpcOptions rpcOptions = RpcOptions.newDefault();
+        rpcOptions.setTlsOptions(tlsOptions);
+        return createWithRpcOptions(
+                endpoint, allocatorInitReservation, allocatorMaxAllocation, compressionType, rpcOptions);
+    }
+
+    /**
+     * Creates a bulk write manager using the supplied RPC channel options.
+     * Only the channel-related options {@code maxInboundMessageSize}, {@code flowControlWindow},
+     * {@code idleTimeoutSeconds}, {@code keepAliveTimeSeconds}, {@code keepAliveTimeoutSeconds},
+     * {@code keepAliveWithoutCalls}, and TLS apply to Bulk API. {@code defaultRpcTimeout},
+     * {@code useRpcSharedPool}, limiter options, and {@code enableMetricInterceptor} apply only to Regular API
+     * and have no effect here.
+     *
+     * @param endpoint the endpoint of the server
+     * @param allocatorInitReservation the initial space reservation (obtained from this allocator)
+     * @param allocatorMaxAllocation the maximum amount of space the new child allocator can allocate
+     * @param compressionType the compression type to use for arrow messages
+     * @param rpcOptions the RPC options containing channel and TLS configuration
+     * @return a BulkWriteManager instance
+     */
+    public static BulkWriteManager createWithRpcOptions(
+            Endpoint endpoint,
+            long allocatorInitReservation,
+            long allocatorMaxAllocation,
+            ArrowCompressionType compressionType,
+            RpcOptions rpcOptions) {
+        return createWithRpcOptions(
+                getRootAllocator(),
+                endpoint,
+                allocatorInitReservation,
+                allocatorMaxAllocation,
+                compressionType,
+                rpcOptions);
+    }
+
+    static BulkWriteManager createWithRpcOptions(
+            BufferAllocator parentAllocator,
+            Endpoint endpoint,
+            long allocatorInitReservation,
+            long allocatorMaxAllocation,
+            ArrowCompressionType compressionType,
+            RpcOptions rpcOptions) {
         Location location = Location.forGrpcInsecure(endpoint.getAddr(), endpoint.getPort());
 
         String allocatorName = String.format("BufferAllocator(%s)", location);
         BufferAllocator allocator =
-                getRootAllocator().newChildAllocator(allocatorName, allocatorInitReservation, allocatorMaxAllocation);
+                parentAllocator.newChildAllocator(allocatorName, allocatorInitReservation, allocatorMaxAllocation);
         Ensures.ensureNonNull(
                 allocator,
                 "Failed to create child buffer allocator, initReservation: %s, maxAllocation: %s",
                 allocatorInitReservation,
                 allocatorMaxAllocation);
 
-        BulkFlightClient flightClient = BulkFlightClient.builder()
-                .location(location)
-                .allocator(allocator)
-                .compressionType(compressionType)
-                .tlsOptions(tlsOptions)
-                .build();
-        BulkWriteManager client = new BulkWriteManager(endpoint, flightClient, allocator);
-
-        LOG.info("BulkWriteManager created: {}", client);
-
-        return client;
+        BulkFlightClient flightClient = null;
+        try {
+            flightClient = BulkFlightClient.builder()
+                    .location(location)
+                    .allocator(allocator)
+                    .compressionType(compressionType)
+                    .rpcOptions(rpcOptions)
+                    .build();
+            BulkWriteManager client = new BulkWriteManager(endpoint, flightClient, allocator);
+            LOG.info("BulkWriteManager created: {}", client);
+            return client;
+        } catch (RuntimeException | Error failure) {
+            if (flightClient != null) {
+                try {
+                    flightClient.close();
+                } catch (InterruptedException closeFailure) {
+                    Thread.currentThread().interrupt();
+                    failure.addSuppressed(closeFailure);
+                } catch (RuntimeException | Error closeFailure) {
+                    failure.addSuppressed(closeFailure);
+                }
+            }
+            try {
+                allocator.close();
+            } catch (RuntimeException | Error closeFailure) {
+                failure.addSuppressed(closeFailure);
+            }
+            throw failure;
+        }
     }
 
     /**

--- a/ingester-bulk-protocol/src/main/java/org/apache/arrow/flight/BulkFlightClient.java
+++ b/ingester-bulk-protocol/src/main/java/org/apache/arrow/flight/BulkFlightClient.java
@@ -19,6 +19,7 @@ package org.apache.arrow.flight;
 import com.codahale.metrics.Timer;
 import io.greptime.ArrowCompressionType;
 import io.greptime.common.util.MetricsUtil;
+import io.greptime.rpc.RpcOptions;
 import io.greptime.rpc.TlsOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -88,13 +89,18 @@ public class BulkFlightClient implements AutoCloseable {
         this.channel = channel;
         this.middleware = middleware;
         this.compressionType = compressionType;
-        ClientInterceptor[] interceptors = new ClientInterceptor[] {new ClientInterceptorAdapter(middleware)};
+        try {
+            ClientInterceptor[] interceptors = new ClientInterceptor[] {new ClientInterceptorAdapter(middleware)};
 
-        // Create a channel with interceptors pre-applied for DoGet and DoPut
-        Channel interceptedChannel = ClientInterceptors.intercept(channel, interceptors);
+            // Create a channel with interceptors pre-applied for DoGet and DoPut
+            Channel interceptedChannel = ClientInterceptors.intercept(channel, interceptors);
 
-        this.asyncStub = FlightServiceGrpc.newStub(interceptedChannel);
-        this.doPutDescriptor = FlightBindingService.getDoPutDescriptor(this.allocator);
+            this.asyncStub = FlightServiceGrpc.newStub(interceptedChannel);
+            this.doPutDescriptor = FlightBindingService.getDoPutDescriptor(this.allocator);
+        } catch (RuntimeException | Error failure) {
+            closeAllocator(this.allocator, failure);
+            throw failure;
+        }
     }
 
     /**
@@ -435,8 +441,31 @@ public class BulkFlightClient implements AutoCloseable {
      * Shut down this client.
      */
     public void close() throws InterruptedException {
-        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
-        allocator.close();
+        Throwable failure = null;
+        try {
+            channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException | RuntimeException | Error closeFailure) {
+            failure = closeFailure;
+        }
+
+        try {
+            allocator.close();
+        } catch (RuntimeException | Error closeFailure) {
+            if (failure == null) {
+                throw closeFailure;
+            }
+            failure.addSuppressed(closeFailure);
+        }
+
+        if (failure instanceof InterruptedException) {
+            throw (InterruptedException) failure;
+        }
+        if (failure instanceof RuntimeException) {
+            throw (RuntimeException) failure;
+        }
+        if (failure instanceof Error) {
+            throw (Error) failure;
+        }
     }
 
     /**
@@ -461,9 +490,10 @@ public class BulkFlightClient implements AutoCloseable {
     public static final class Builder {
         private BufferAllocator allocator;
         private Location location;
-        private int maxInboundMessageSize = FlightServer.MAX_GRPC_MESSAGE_SIZE;
+        private Integer maxInboundMessageSize;
         private List<FlightClientMiddleware.Factory> middleware = new ArrayList<>();
         private ArrowCompressionType compressionType = ArrowCompressionType.None;
+        private RpcOptions rpcOptions = RpcOptions.newDefault();
         private TlsOptions tlsOptions;
 
         private Builder() {}
@@ -500,9 +530,54 @@ public class BulkFlightClient implements AutoCloseable {
             return this;
         }
 
+        public Builder rpcOptions(RpcOptions rpcOptions) {
+            this.rpcOptions = Preconditions.checkNotNull(rpcOptions).copy();
+            return this;
+        }
+
         public Builder tlsOptions(TlsOptions tlsOptions) {
             this.tlsOptions = tlsOptions;
             return this;
+        }
+
+        NettyChannelBuilder configureChannel(NettyChannelBuilder builder) {
+            TlsOptions resolvedTlsOptions = this.tlsOptions != null ? this.tlsOptions : this.rpcOptions.getTlsOptions();
+            if (resolvedTlsOptions != null) {
+                builder.useTransportSecurity();
+                try {
+                    SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
+                    Optional<File> clientCertChain = resolvedTlsOptions.getClientCertChain();
+                    Optional<File> privateKey = resolvedTlsOptions.getPrivateKey();
+                    Optional<String> privateKeyPassword = resolvedTlsOptions.getPrivateKeyPassword();
+
+                    if (clientCertChain.isPresent() && privateKey.isPresent()) {
+                        if (privateKeyPassword.isPresent()) {
+                            sslContextBuilder.keyManager(
+                                    clientCertChain.get(), privateKey.get(), privateKeyPassword.get());
+                        } else {
+                            sslContextBuilder.keyManager(clientCertChain.get(), privateKey.get());
+                        }
+                    }
+
+                    resolvedTlsOptions.getRootCerts().ifPresent(sslContextBuilder::trustManager);
+                    builder.sslContext(sslContextBuilder.build());
+                } catch (SSLException e) {
+                    throw new RuntimeException("Failed to configure SslContext", e);
+                }
+            } else {
+                builder.usePlaintext();
+            }
+
+            int resolvedMaxInboundMessageSize = this.maxInboundMessageSize != null
+                    ? this.maxInboundMessageSize
+                    : this.rpcOptions.getMaxInboundMessageSize();
+            return builder.maxTraceEvents(MAX_CHANNEL_TRACE_EVENTS)
+                    .maxInboundMessageSize(resolvedMaxInboundMessageSize)
+                    .flowControlWindow(this.rpcOptions.getFlowControlWindow())
+                    .idleTimeout(this.rpcOptions.getIdleTimeoutSeconds(), TimeUnit.SECONDS)
+                    .keepAliveTime(this.rpcOptions.getKeepAliveTimeSeconds(), TimeUnit.SECONDS)
+                    .keepAliveTimeout(this.rpcOptions.getKeepAliveTimeoutSeconds(), TimeUnit.SECONDS)
+                    .keepAliveWithoutCalls(this.rpcOptions.isKeepAliveWithoutCalls());
         }
 
         /**
@@ -523,34 +598,29 @@ public class BulkFlightClient implements AutoCloseable {
                             "Scheme is not supported: " + this.location.getUri().getScheme());
             }
 
-            if (this.tlsOptions != null) {
-                builder.useTransportSecurity();
+            configureChannel(builder);
+            return build(builder.build());
+        }
+
+        BulkFlightClient build(ManagedChannel channel) {
+            try {
+                return new BulkFlightClient(this.allocator, channel, this.middleware, this.compressionType);
+            } catch (RuntimeException | Error failure) {
                 try {
-                    SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
-                    Optional<File> clientCertChain = this.tlsOptions.getClientCertChain();
-                    Optional<File> privateKey = this.tlsOptions.getPrivateKey();
-                    Optional<String> privateKeyPassword = this.tlsOptions.getPrivateKeyPassword();
-
-                    if (clientCertChain.isPresent() && privateKey.isPresent()) {
-                        if (privateKeyPassword.isPresent()) {
-                            sslContextBuilder.keyManager(
-                                    clientCertChain.get(), privateKey.get(), privateKeyPassword.get());
-                        } else {
-                            sslContextBuilder.keyManager(clientCertChain.get(), privateKey.get());
-                        }
-                    }
-
-                    this.tlsOptions.getRootCerts().ifPresent(sslContextBuilder::trustManager);
-                    builder.sslContext(sslContextBuilder.build());
-                } catch (SSLException e) {
-                    throw new RuntimeException("Failed to configure SslContext", e);
+                    channel.shutdownNow();
+                } catch (RuntimeException | Error closeFailure) {
+                    failure.addSuppressed(closeFailure);
                 }
-            } else {
-                builder.usePlaintext();
+                throw failure;
             }
+        }
+    }
 
-            builder.maxTraceEvents(MAX_CHANNEL_TRACE_EVENTS).maxInboundMessageSize(this.maxInboundMessageSize);
-            return new BulkFlightClient(this.allocator, builder.build(), this.middleware, this.compressionType);
+    private static void closeAllocator(BufferAllocator allocator, Throwable failure) {
+        try {
+            allocator.close();
+        } catch (RuntimeException | Error closeFailure) {
+            failure.addSuppressed(closeFailure);
         }
     }
 

--- a/ingester-bulk-protocol/src/main/java/org/apache/arrow/flight/BulkFlightClient.java
+++ b/ingester-bulk-protocol/src/main/java/org/apache/arrow/flight/BulkFlightClient.java
@@ -444,7 +444,10 @@ public class BulkFlightClient implements AutoCloseable {
         Throwable failure = null;
         try {
             channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
-        } catch (InterruptedException | RuntimeException | Error closeFailure) {
+        } catch (InterruptedException closeFailure) {
+            failure = closeFailure;
+            Thread.currentThread().interrupt();
+        } catch (RuntimeException | Error closeFailure) {
             failure = closeFailure;
         }
 

--- a/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteManagerCompatibilityTest.java
+++ b/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteManagerCompatibilityTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.greptime;
+
+import java.util.concurrent.Callable;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BulkWriteManagerCompatibilityTest {
+
+    @Test
+    public void testLegacyCreateAcceptsNullTlsOptionsWithoutAmbiguousOverload() {
+        Callable<BulkWriteManager> legacyCall =
+                () -> BulkWriteManager.create(null, 0, 0, ArrowCompressionType.None, null);
+
+        Assert.assertNotNull(legacyCall);
+    }
+}

--- a/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteManagerTest.java
+++ b/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteManagerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.greptime;
+
+import io.greptime.common.Endpoint;
+import io.greptime.rpc.RpcOptions;
+import java.util.ArrayList;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BulkWriteManagerTest {
+
+    @Test
+    public void testCreateFailureClosesChildAllocator() throws Exception {
+        try (BufferAllocator parentAllocator = new RootAllocator(Long.MAX_VALUE)) {
+            RuntimeException constructionFailure = new RuntimeException("channel configuration failed");
+            RpcOptions rpcOptions = new RpcOptions() {
+                @Override
+                public RpcOptions copy() {
+                    return this;
+                }
+
+                @Override
+                public int getFlowControlWindow() {
+                    throw constructionFailure;
+                }
+            };
+            BulkWriteManager manager = null;
+            RuntimeException failure = null;
+            int childrenAfterFailure;
+            try {
+                manager = BulkWriteManager.createWithRpcOptions(
+                        parentAllocator,
+                        Endpoint.of("localhost", 4001),
+                        0,
+                        Long.MAX_VALUE,
+                        ArrowCompressionType.None,
+                        rpcOptions);
+                Assert.fail("Expected invalid flow control window to fail");
+            } catch (RuntimeException e) {
+                failure = e;
+            } finally {
+                childrenAfterFailure = parentAllocator.getChildAllocators().size();
+                try {
+                    if (manager != null) {
+                        manager.close();
+                    }
+                } finally {
+                    for (BufferAllocator child : new ArrayList<>(parentAllocator.getChildAllocators())) {
+                        child.close();
+                    }
+                }
+            }
+
+            Assert.assertSame(constructionFailure, failure);
+            Assert.assertEquals(0, childrenAfterFailure);
+        }
+    }
+}

--- a/ingester-bulk-protocol/src/test/java/org/apache/arrow/flight/BulkFlightClientTest.java
+++ b/ingester-bulk-protocol/src/test/java/org/apache/arrow/flight/BulkFlightClientTest.java
@@ -170,26 +170,32 @@ public class BulkFlightClientTest {
 
     @Test
     public void testCloseClosesChildAllocatorWhenChannelShutdownIsInterrupted() throws Exception {
-        BufferAllocator parentAllocator = Mockito.mock(BufferAllocator.class);
-        BufferAllocator childAllocator = Mockito.mock(BufferAllocator.class);
-        Mockito.when(parentAllocator.newChildAllocator("bulk-flight-client", 0, Long.MAX_VALUE))
-                .thenReturn(childAllocator);
-        ManagedChannel channel = Mockito.mock(ManagedChannel.class);
-        Mockito.when(channel.shutdown()).thenReturn(channel);
-        InterruptedException interruption = new InterruptedException("channel shutdown interrupted");
-        Mockito.when(channel.awaitTermination(5, TimeUnit.SECONDS)).thenThrow(interruption);
-        BulkFlightClient client =
-                new BulkFlightClient(parentAllocator, channel, Collections.emptyList(), ArrowCompressionType.None);
-
-        InterruptedException failure = null;
+        Thread.interrupted();
         try {
-            client.close();
-            Assert.fail("Expected interrupted channel shutdown");
-        } catch (InterruptedException e) {
-            failure = e;
-        }
+            BufferAllocator parentAllocator = Mockito.mock(BufferAllocator.class);
+            BufferAllocator childAllocator = Mockito.mock(BufferAllocator.class);
+            Mockito.when(parentAllocator.newChildAllocator("bulk-flight-client", 0, Long.MAX_VALUE))
+                    .thenReturn(childAllocator);
+            ManagedChannel channel = Mockito.mock(ManagedChannel.class);
+            Mockito.when(channel.shutdown()).thenReturn(channel);
+            InterruptedException interruption = new InterruptedException("channel shutdown interrupted");
+            Mockito.when(channel.awaitTermination(5, TimeUnit.SECONDS)).thenThrow(interruption);
+            BulkFlightClient client =
+                    new BulkFlightClient(parentAllocator, channel, Collections.emptyList(), ArrowCompressionType.None);
 
-        Assert.assertSame(interruption, failure);
-        Mockito.verify(childAllocator).close();
+            InterruptedException failure = null;
+            try {
+                client.close();
+                Assert.fail("Expected interrupted channel shutdown");
+            } catch (InterruptedException e) {
+                failure = e;
+            }
+
+            Assert.assertSame(interruption, failure);
+            Mockito.verify(childAllocator).close();
+            Assert.assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
     }
 }

--- a/ingester-bulk-protocol/src/test/java/org/apache/arrow/flight/BulkFlightClientTest.java
+++ b/ingester-bulk-protocol/src/test/java/org/apache/arrow/flight/BulkFlightClientTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2023 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight;
+
+import io.greptime.ArrowCompressionType;
+import io.greptime.rpc.RpcOptions;
+import io.greptime.rpc.TlsOptions;
+import io.grpc.ManagedChannel;
+import io.grpc.netty.NegotiationType;
+import io.grpc.netty.NettyChannelBuilder;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class BulkFlightClientTest {
+
+    @Test
+    public void testRpcOptionsConfigureChannel() throws Exception {
+        RpcOptions rpcOptions = RpcOptions.newDefault();
+        rpcOptions.setMaxInboundMessageSize(1_234_567);
+        rpcOptions.setFlowControlWindow(2_345_678);
+        rpcOptions.setIdleTimeoutSeconds(47);
+        rpcOptions.setKeepAliveTimeSeconds(53);
+        rpcOptions.setKeepAliveTimeoutSeconds(59);
+        rpcOptions.setKeepAliveWithoutCalls(true);
+
+        BulkFlightClient.Builder clientBuilder = BulkFlightClient.builder().rpcOptions(rpcOptions);
+        rpcOptions.setMaxInboundMessageSize(1);
+        rpcOptions.setFlowControlWindow(1);
+        rpcOptions.setIdleTimeoutSeconds(1);
+        rpcOptions.setKeepAliveTimeSeconds(1);
+        rpcOptions.setKeepAliveTimeoutSeconds(1);
+        rpcOptions.setKeepAliveWithoutCalls(false);
+
+        NettyChannelBuilder channelBuilder = NettyChannelBuilder.forAddress("localhost", 4001);
+        clientBuilder.configureChannel(channelBuilder);
+        NettyChannelBuilderInspector inspector = NettyChannelBuilderInspector.inspect(channelBuilder);
+
+        Assert.assertEquals(1_234_567, inspector.maxInboundMessageSize());
+        Assert.assertEquals(2_345_678, inspector.flowControlWindow());
+        Assert.assertEquals(47, inspector.idleTimeoutSeconds());
+        Assert.assertEquals(53, inspector.keepAliveTimeSeconds());
+        Assert.assertEquals(59, inspector.keepAliveTimeoutSeconds());
+        Assert.assertTrue(inspector.keepAliveWithoutCalls());
+        Assert.assertEquals(0, inspector.maxTraceEvents());
+    }
+
+    @Test
+    public void testExplicitMaxInboundMessageSizeOverridesRpcOptions() throws Exception {
+        RpcOptions rpcOptions = RpcOptions.newDefault();
+        rpcOptions.setMaxInboundMessageSize(1_234_567);
+        NettyChannelBuilder channelBuilder = NettyChannelBuilder.forAddress("localhost", 4001);
+
+        BulkFlightClient.builder()
+                .rpcOptions(rpcOptions)
+                .maxInboundMessageSize(7_654_321)
+                .configureChannel(channelBuilder);
+
+        Assert.assertEquals(
+                7_654_321, NettyChannelBuilderInspector.inspect(channelBuilder).maxInboundMessageSize());
+    }
+
+    @Test
+    public void testRpcOptionsDefaultWhenAbsent() throws Exception {
+        RpcOptions defaults = RpcOptions.newDefault();
+        NettyChannelBuilder channelBuilder = NettyChannelBuilder.forAddress("localhost", 4001);
+
+        BulkFlightClient.builder().configureChannel(channelBuilder);
+        NettyChannelBuilderInspector inspector = NettyChannelBuilderInspector.inspect(channelBuilder);
+
+        Assert.assertEquals(defaults.getMaxInboundMessageSize(), inspector.maxInboundMessageSize());
+        Assert.assertEquals(defaults.getFlowControlWindow(), inspector.flowControlWindow());
+        Assert.assertEquals(defaults.getKeepAliveTimeSeconds(), inspector.keepAliveTimeSeconds());
+    }
+
+    @Test
+    public void testTlsResolutionPrefersExplicitThenRpcThenPlaintext() throws Exception {
+        RpcOptions rpcOptions = RpcOptions.newDefault();
+        TlsOptions invalidRpcTls = new TlsOptions();
+        invalidRpcTls.setRootCerts(new File("missing-rpc-root-certificate.pem"));
+        rpcOptions.setTlsOptions(invalidRpcTls);
+
+        NettyChannelBuilder explicitTlsChannel = NettyChannelBuilder.forAddress("localhost", 4001);
+        BulkFlightClient.builder()
+                .rpcOptions(rpcOptions)
+                .tlsOptions(new TlsOptions())
+                .configureChannel(explicitTlsChannel);
+
+        RpcOptions rpcTlsOptions = RpcOptions.newDefault();
+        rpcTlsOptions.setTlsOptions(new TlsOptions());
+        NettyChannelBuilder rpcTlsChannel = NettyChannelBuilder.forAddress("localhost", 4001);
+        BulkFlightClient.builder().rpcOptions(rpcTlsOptions).configureChannel(rpcTlsChannel);
+
+        NettyChannelBuilder plaintextChannel = NettyChannelBuilder.forAddress("localhost", 4001);
+        BulkFlightClient.builder().configureChannel(plaintextChannel);
+
+        Assert.assertEquals(
+                NegotiationType.TLS,
+                NettyChannelBuilderInspector.inspect(explicitTlsChannel).negotiationType());
+        Assert.assertEquals(
+                NegotiationType.TLS,
+                NettyChannelBuilderInspector.inspect(rpcTlsChannel).negotiationType());
+        Assert.assertEquals(
+                NegotiationType.PLAINTEXT,
+                NettyChannelBuilderInspector.inspect(plaintextChannel).negotiationType());
+    }
+
+    @Test
+    public void testConstructorFailureClosesChildAllocator() throws Exception {
+        try (BufferAllocator parentAllocator = new RootAllocator(Long.MAX_VALUE)) {
+            RuntimeException failure = null;
+            int childrenAfter;
+            try {
+                new BulkFlightClient(parentAllocator, null, Collections.emptyList(), ArrowCompressionType.None);
+                Assert.fail("Expected null channel to fail client construction");
+            } catch (RuntimeException e) {
+                failure = e;
+            } finally {
+                childrenAfter = parentAllocator.getChildAllocators().size();
+                for (BufferAllocator child : new ArrayList<>(parentAllocator.getChildAllocators())) {
+                    child.close();
+                }
+            }
+
+            Assert.assertTrue(failure instanceof NullPointerException);
+            Assert.assertEquals(0, childrenAfter);
+        }
+    }
+
+    @Test
+    public void testBuilderClosesChannelWhenClientConstructionFails() {
+        BufferAllocator allocator = Mockito.mock(BufferAllocator.class);
+        RuntimeException constructionFailure = new RuntimeException("child allocation failed");
+        Mockito.when(allocator.newChildAllocator("bulk-flight-client", 0, Long.MAX_VALUE))
+                .thenThrow(constructionFailure);
+        ManagedChannel channel = Mockito.mock(ManagedChannel.class);
+        Mockito.when(channel.shutdownNow()).thenReturn(channel);
+
+        RuntimeException failure = null;
+        try {
+            BulkFlightClient.builder().allocator(allocator).build(channel);
+            Assert.fail("Expected client construction to fail");
+        } catch (RuntimeException e) {
+            failure = e;
+        }
+
+        Assert.assertSame(constructionFailure, failure);
+        Mockito.verify(channel).shutdownNow();
+    }
+
+    @Test
+    public void testCloseClosesChildAllocatorWhenChannelShutdownIsInterrupted() throws Exception {
+        BufferAllocator parentAllocator = Mockito.mock(BufferAllocator.class);
+        BufferAllocator childAllocator = Mockito.mock(BufferAllocator.class);
+        Mockito.when(parentAllocator.newChildAllocator("bulk-flight-client", 0, Long.MAX_VALUE))
+                .thenReturn(childAllocator);
+        ManagedChannel channel = Mockito.mock(ManagedChannel.class);
+        Mockito.when(channel.shutdown()).thenReturn(channel);
+        InterruptedException interruption = new InterruptedException("channel shutdown interrupted");
+        Mockito.when(channel.awaitTermination(5, TimeUnit.SECONDS)).thenThrow(interruption);
+        BulkFlightClient client =
+                new BulkFlightClient(parentAllocator, channel, Collections.emptyList(), ArrowCompressionType.None);
+
+        InterruptedException failure = null;
+        try {
+            client.close();
+            Assert.fail("Expected interrupted channel shutdown");
+        } catch (InterruptedException e) {
+            failure = e;
+        }
+
+        Assert.assertSame(interruption, failure);
+        Mockito.verify(childAllocator).close();
+    }
+}

--- a/ingester-bulk-protocol/src/test/java/org/apache/arrow/flight/NettyChannelBuilderInspector.java
+++ b/ingester-bulk-protocol/src/test/java/org/apache/arrow/flight/NettyChannelBuilderInspector.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight;
+
+import io.grpc.netty.NegotiationType;
+import io.grpc.netty.NettyChannelBuilder;
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+
+// Version-coupled to grpc-netty internals; keep all private-field knowledge isolated here.
+final class NettyChannelBuilderInspector {
+    private final NettyChannelBuilder builder;
+
+    private NettyChannelBuilderInspector(NettyChannelBuilder builder) {
+        this.builder = builder;
+    }
+
+    static NettyChannelBuilderInspector inspect(NettyChannelBuilder builder) {
+        return new NettyChannelBuilderInspector(builder);
+    }
+
+    int maxInboundMessageSize() throws Exception {
+        return (Integer) field(builder, "maxInboundMessageSize");
+    }
+
+    int flowControlWindow() throws Exception {
+        return (Integer) field(builder, "flowControlWindow");
+    }
+
+    long idleTimeoutSeconds() throws Exception {
+        long timeoutMillis = (Long) field(delegate(), "idleTimeoutMillis");
+        return TimeUnit.MILLISECONDS.toSeconds(timeoutMillis);
+    }
+
+    long keepAliveTimeSeconds() throws Exception {
+        long timeNanos = (Long) field(builder, "keepAliveTimeNanos");
+        return TimeUnit.NANOSECONDS.toSeconds(timeNanos);
+    }
+
+    long keepAliveTimeoutSeconds() throws Exception {
+        long timeoutNanos = (Long) field(builder, "keepAliveTimeoutNanos");
+        return TimeUnit.NANOSECONDS.toSeconds(timeoutNanos);
+    }
+
+    boolean keepAliveWithoutCalls() throws Exception {
+        return (Boolean) field(builder, "keepAliveWithoutCalls");
+    }
+
+    int maxTraceEvents() throws Exception {
+        return (Integer) field(delegate(), "maxTraceEvents");
+    }
+
+    NegotiationType negotiationType() throws Exception {
+        Object negotiator = field(builder, "protocolNegotiatorFactory");
+        return (NegotiationType) field(negotiator, "negotiationType");
+    }
+
+    private Object delegate() throws Exception {
+        return field(builder, "managedChannelImplBuilder");
+    }
+
+    private static Object field(Object target, String name) throws Exception {
+        Class<?> type = target.getClass();
+        while (type != null) {
+            try {
+                Field field = type.getDeclaredField(name);
+                field.setAccessible(true);
+                return field.get(target);
+            } catch (NoSuchFieldException ignored) {
+                type = type.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+}

--- a/ingester-protocol/src/main/java/io/greptime/BulkWriteClient.java
+++ b/ingester-protocol/src/main/java/io/greptime/BulkWriteClient.java
@@ -132,7 +132,7 @@ public class BulkWriteClient implements BulkWrite, Health, Lifecycle<BulkWriteOp
         Schema arrowSchema = ArrowHelper.createSchema(schema);
         ArrowCompressionType compressionType = ArrowHelper.getArrowCompressionType(ctx);
 
-        BulkWriteManager manager = BulkWriteManager.createWithRpcOptions(
+        BulkWriteManager manager = createBulkWriteManager(
                 endpoint, allocatorInitReservation, allocatorMaxAllocation, compressionType, rpcOptions);
 
         // Creates the bulk write service
@@ -155,6 +155,16 @@ public class BulkWriteClient implements BulkWrite, Health, Lifecycle<BulkWriteOp
             writer.tryUseZeroCopyWrite();
         }
         return new DefaultBulkStreamWriter(writer, schema, maxRequestsInFlight);
+    }
+
+    BulkWriteManager createBulkWriteManager(
+            Endpoint endpoint,
+            long allocatorInitReservation,
+            long allocatorMaxAllocation,
+            ArrowCompressionType compressionType,
+            RpcOptions rpcOptions) {
+        return BulkWriteManager.createWithRpcOptions(
+                endpoint, allocatorInitReservation, allocatorMaxAllocation, compressionType, rpcOptions);
     }
 
     @Override

--- a/ingester-protocol/src/main/java/io/greptime/BulkWriteClient.java
+++ b/ingester-protocol/src/main/java/io/greptime/BulkWriteClient.java
@@ -35,6 +35,7 @@ import io.greptime.models.Table;
 import io.greptime.models.TableSchema;
 import io.greptime.options.BulkWriteOptions;
 import io.greptime.rpc.Context;
+import io.greptime.rpc.RpcOptions;
 import io.greptime.rpc.TlsOptions;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -118,13 +119,21 @@ public class BulkWriteClient implements BulkWrite, Health, Lifecycle<BulkWriteOp
             int maxRequestsInFlight,
             Context ctx) {
         // Creates the bulk write manager
-        TlsOptions tlsOptions = this.opts.getTlsOptions();
+        RpcOptions rpcOptions = this.opts.getRpcOptions();
+        if (rpcOptions == null) {
+            rpcOptions = RpcOptions.newDefault();
+        }
+        TlsOptions legacyTlsOptions = this.opts.getTlsOptions();
+        if (legacyTlsOptions != null) {
+            rpcOptions = rpcOptions.copy();
+            rpcOptions.setTlsOptions(legacyTlsOptions);
+        }
 
         Schema arrowSchema = ArrowHelper.createSchema(schema);
         ArrowCompressionType compressionType = ArrowHelper.getArrowCompressionType(ctx);
 
-        BulkWriteManager manager = BulkWriteManager.create(
-                endpoint, allocatorInitReservation, allocatorMaxAllocation, compressionType, tlsOptions);
+        BulkWriteManager manager = BulkWriteManager.createWithRpcOptions(
+                endpoint, allocatorInitReservation, allocatorMaxAllocation, compressionType, rpcOptions);
 
         // Creates the bulk write service
         String database = this.opts.getDatabase();

--- a/ingester-protocol/src/main/java/io/greptime/options/BulkWriteOptions.java
+++ b/ingester-protocol/src/main/java/io/greptime/options/BulkWriteOptions.java
@@ -103,7 +103,9 @@ public class BulkWriteOptions implements Copiable<BulkWriteOptions> {
         if (this.rpcOptions != null) {
             opts.rpcOptions = this.rpcOptions.copy();
         }
-        opts.tlsOptions = this.tlsOptions;
+        if (this.tlsOptions != null) {
+            opts.tlsOptions = this.tlsOptions.copy();
+        }
         return opts;
     }
 

--- a/ingester-protocol/src/main/java/io/greptime/options/BulkWriteOptions.java
+++ b/ingester-protocol/src/main/java/io/greptime/options/BulkWriteOptions.java
@@ -19,6 +19,7 @@ package io.greptime.options;
 import io.greptime.RouterClient;
 import io.greptime.common.Copiable;
 import io.greptime.models.AuthInfo;
+import io.greptime.rpc.RpcOptions;
 import io.greptime.rpc.TlsOptions;
 import java.util.concurrent.Executor;
 
@@ -31,6 +32,7 @@ public class BulkWriteOptions implements Copiable<BulkWriteOptions> {
     private RouterClient routerClient;
     private Executor asyncPool;
     private boolean useZeroCopyWrite;
+    private RpcOptions rpcOptions;
     // GreptimeDB secure connection options
     private TlsOptions tlsOptions;
 
@@ -74,6 +76,14 @@ public class BulkWriteOptions implements Copiable<BulkWriteOptions> {
         this.useZeroCopyWrite = useZeroCopyWrite;
     }
 
+    public RpcOptions getRpcOptions() {
+        return rpcOptions;
+    }
+
+    public void setRpcOptions(RpcOptions rpcOptions) {
+        this.rpcOptions = rpcOptions;
+    }
+
     public TlsOptions getTlsOptions() {
         return tlsOptions;
     }
@@ -90,6 +100,9 @@ public class BulkWriteOptions implements Copiable<BulkWriteOptions> {
         opts.routerClient = this.routerClient;
         opts.asyncPool = this.asyncPool;
         opts.useZeroCopyWrite = this.useZeroCopyWrite;
+        if (this.rpcOptions != null) {
+            opts.rpcOptions = this.rpcOptions.copy();
+        }
         opts.tlsOptions = this.tlsOptions;
         return opts;
     }
@@ -102,6 +115,7 @@ public class BulkWriteOptions implements Copiable<BulkWriteOptions> {
                 + ", routerClient=" + routerClient
                 + ", asyncPool=" + asyncPool
                 + ", useZeroCopyWrite=" + useZeroCopyWrite
+                + ", rpcOptions=" + rpcOptions
                 + ", tlsOptions=" + tlsOptions
                 + '}';
     }

--- a/ingester-protocol/src/main/java/io/greptime/options/GreptimeOptions.java
+++ b/ingester-protocol/src/main/java/io/greptime/options/GreptimeOptions.java
@@ -218,7 +218,10 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
         /**
          * Sets the RPC options. In general, the default configuration is fine.
          *
-         * <p>This configuration only applies to Regular API, not to Bulk API.
+         * <p>The channel-related options {@code maxInboundMessageSize}, {@code flowControlWindow},
+         * {@code idleTimeoutSeconds}, {@code keepAliveTimeSeconds}, {@code keepAliveTimeoutSeconds}, and
+         * {@code keepAliveWithoutCalls} apply to both Regular API and Bulk API. {@code useRpcSharedPool},
+         * {@code defaultRpcTimeout}, limiter options, and {@code enableMetricInterceptor} apply only to Regular API.
          *
          * <p>Key parameters include:
          * <ul>
@@ -227,7 +230,8 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
          *   <li>maxInboundMessageSize: Maximum inbound message size (default: 256MB)</li>
          *   <li>flowControlWindow: Flow control window size (default: 256MB)</li>
          *   <li>idleTimeoutSeconds: Idle timeout duration (default: 5 minutes)</li>
-         *   <li>keepAliveTimeSeconds: Keep-alive ping interval (default: disabled)</li>
+         *   <li>keepAliveTimeSeconds: Duration without read activity before sending a keep-alive ping
+         *       (default: 60 seconds)</li>
          *   <li>limitKind: gRPC layer concurrency limit algorithm (default: None)</li>
          * </ul>
          *
@@ -242,6 +246,7 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
         /**
          * Set `TlsOptions` to use secure connection between client and server. Set to `null` to use
          * plaintext connection instead.
+         * This configuration applies to both Regular API and Bulk API.
          *
          * <p>Key parameters include:
          * <ul>
@@ -448,6 +453,7 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
             bulkWriteOpts.setAuthInfo(this.authInfo);
             bulkWriteOpts.setAsyncPool(this.asyncPool);
             bulkWriteOpts.setUseZeroCopyWrite(this.useZeroCopyWriteInBulkWrite);
+            bulkWriteOpts.setRpcOptions(this.rpcOptions == null ? null : this.rpcOptions.copy());
             bulkWriteOpts.setTlsOptions(this.tlsOptions);
             return bulkWriteOpts;
         }

--- a/ingester-protocol/src/main/java/io/greptime/options/GreptimeOptions.java
+++ b/ingester-protocol/src/main/java/io/greptime/options/GreptimeOptions.java
@@ -110,6 +110,9 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
         if (this.writeOptions != null) {
             opts.writeOptions = this.writeOptions.copy();
         }
+        if (this.bulkWriteOptions != null) {
+            opts.bulkWriteOptions = this.bulkWriteOptions.copy();
+        }
         return opts;
     }
 
@@ -161,6 +164,7 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
         private RpcOptions rpcOptions = RpcOptions.newDefault();
         // GreptimeDB secure connection options
         private TlsOptions tlsOptions;
+        private boolean tlsOptionsConfigured;
         private int writeMaxRetries = DEFAULT_WRITE_MAX_RETRIES;
         // Write flow limit: maximum number of data points in-flight.
         private int maxInFlightWritePoints = DEFAULT_MAX_IN_FLIGHT_WRITE_POINTS;
@@ -261,6 +265,7 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
          */
         public Builder tlsOptions(TlsOptions tlsOptions) {
             this.tlsOptions = tlsOptions;
+            this.tlsOptionsConfigured = true;
             return this;
         }
 
@@ -412,17 +417,18 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
          * @return nice things
          */
         public GreptimeOptions build() {
-            // Set tls options to rpc options if tls options is not null
-            if (this.tlsOptions != null && this.rpcOptions != null) {
-                this.rpcOptions.setTlsOptions(this.tlsOptions);
+            RpcOptions effectiveRpcOptions = this.rpcOptions;
+            if (this.tlsOptionsConfigured && this.rpcOptions != null) {
+                effectiveRpcOptions = this.rpcOptions.copy();
+                effectiveRpcOptions.setTlsOptions(this.tlsOptions);
             }
             GreptimeOptions opts = new GreptimeOptions();
             opts.setEndpoints(this.endpoints);
-            opts.setRpcOptions(this.rpcOptions);
+            opts.setRpcOptions(effectiveRpcOptions);
             opts.setDatabase(this.database);
             opts.setRouterOptions(routerOptions());
             opts.setWriteOptions(writeOptions());
-            opts.setBulkWriteOptions(bulkWriteOptions());
+            opts.setBulkWriteOptions(bulkWriteOptions(effectiveRpcOptions));
             return GreptimeOptions.checkSelf(opts);
         }
 
@@ -447,13 +453,13 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
             return writeOpts;
         }
 
-        private BulkWriteOptions bulkWriteOptions() {
+        private BulkWriteOptions bulkWriteOptions(RpcOptions effectiveRpcOptions) {
             BulkWriteOptions bulkWriteOpts = new BulkWriteOptions();
             bulkWriteOpts.setDatabase(this.database);
             bulkWriteOpts.setAuthInfo(this.authInfo);
             bulkWriteOpts.setAsyncPool(this.asyncPool);
             bulkWriteOpts.setUseZeroCopyWrite(this.useZeroCopyWriteInBulkWrite);
-            bulkWriteOpts.setRpcOptions(this.rpcOptions == null ? null : this.rpcOptions.copy());
+            bulkWriteOpts.setRpcOptions(effectiveRpcOptions == null ? null : effectiveRpcOptions.copy());
             bulkWriteOpts.setTlsOptions(this.tlsOptions);
             return bulkWriteOpts;
         }

--- a/ingester-protocol/src/test/java/io/greptime/BulkWriteClientTest.java
+++ b/ingester-protocol/src/test/java/io/greptime/BulkWriteClientTest.java
@@ -16,6 +16,14 @@
 
 package io.greptime;
 
+import io.greptime.common.Endpoint;
+import io.greptime.models.DataType;
+import io.greptime.models.TableSchema;
+import io.greptime.options.BulkWriteOptions;
+import io.greptime.rpc.Context;
+import io.greptime.rpc.RpcOptions;
+import io.greptime.rpc.TlsOptions;
+import java.io.File;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -24,6 +32,64 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 public class BulkWriteClientTest {
+
+    @Test
+    public void testBulkStreamWriterForwardsRpcOptionsToManager() {
+        Endpoint endpoint = Endpoint.of("127.0.0.1", 4001);
+        RouterClient routerClient = Mockito.mock(RouterClient.class);
+        Mockito.when(routerClient.route()).thenReturn(CompletableFuture.completedFuture(endpoint));
+
+        RpcOptions rpcOptions = new RpcOptions();
+        rpcOptions.setMaxInboundMessageSize(1_234_567);
+        rpcOptions.setFlowControlWindow(2_345_678);
+        rpcOptions.setIdleTimeoutSeconds(41);
+        rpcOptions.setKeepAliveTimeSeconds(42);
+        rpcOptions.setKeepAliveTimeoutSeconds(43);
+        rpcOptions.setKeepAliveWithoutCalls(true);
+        TlsOptions tlsOptions = new TlsOptions();
+        tlsOptions.setRootCerts(new File("test-root.crt"));
+        rpcOptions.setTlsOptions(tlsOptions);
+
+        BulkWriteOptions options = new BulkWriteOptions();
+        options.setDatabase("test_db");
+        options.setRouterClient(routerClient);
+        options.setAsyncPool(Runnable::run);
+        options.setRpcOptions(rpcOptions);
+
+        BulkWriteManager manager = Mockito.mock(BulkWriteManager.class);
+        BulkWriteService service = Mockito.mock(BulkWriteService.class);
+        Mockito.when(manager.intoBulkWriteStream(
+                        Mockito.eq("test_table"),
+                        Mockito.any(),
+                        Mockito.eq(1_000L),
+                        Mockito.eq(2),
+                        Mockito.any(),
+                        Mockito.any()))
+                .thenReturn(service);
+        CapturingBulkWriteClient client = new CapturingBulkWriteClient(manager);
+        client.init(options);
+
+        TableSchema schema = TableSchema.newBuilder("test_table")
+                .addField("value", DataType.Int64)
+                .build();
+        BulkStreamWriter writer = client.bulkStreamWriter(schema, 128, 4096, 1_000, 2, Context.newDefault());
+
+        Assert.assertNotNull(writer);
+        Assert.assertEquals(endpoint, client.endpoint);
+        Assert.assertEquals(128, client.allocatorInitReservation);
+        Assert.assertEquals(4096, client.allocatorMaxAllocation);
+        Assert.assertEquals(ArrowCompressionType.None, client.compressionType);
+        Assert.assertEquals(1_234_567, client.rpcOptions.getMaxInboundMessageSize());
+        Assert.assertEquals(2_345_678, client.rpcOptions.getFlowControlWindow());
+        Assert.assertEquals(41, client.rpcOptions.getIdleTimeoutSeconds());
+        Assert.assertEquals(42, client.rpcOptions.getKeepAliveTimeSeconds());
+        Assert.assertEquals(43, client.rpcOptions.getKeepAliveTimeoutSeconds());
+        Assert.assertTrue(client.rpcOptions.isKeepAliveWithoutCalls());
+        Assert.assertEquals(
+                new File("test-root.crt"),
+                client.rpcOptions.getTlsOptions().getRootCerts().orElse(null));
+        Mockito.verify(service).start();
+    }
 
     @Test
     public void testTimedGetReportsCallerTimeoutToPutStage() throws Exception {
@@ -39,5 +105,33 @@ public class BulkWriteClientTest {
         }
 
         Mockito.verify(stage).logTimeout(timeout, 1, TimeUnit.MILLISECONDS);
+    }
+
+    private static class CapturingBulkWriteClient extends BulkWriteClient {
+        private final BulkWriteManager manager;
+        private Endpoint endpoint;
+        private long allocatorInitReservation;
+        private long allocatorMaxAllocation;
+        private ArrowCompressionType compressionType;
+        private RpcOptions rpcOptions;
+
+        private CapturingBulkWriteClient(BulkWriteManager manager) {
+            this.manager = manager;
+        }
+
+        @Override
+        BulkWriteManager createBulkWriteManager(
+                Endpoint endpoint,
+                long allocatorInitReservation,
+                long allocatorMaxAllocation,
+                ArrowCompressionType compressionType,
+                RpcOptions rpcOptions) {
+            this.endpoint = endpoint;
+            this.allocatorInitReservation = allocatorInitReservation;
+            this.allocatorMaxAllocation = allocatorMaxAllocation;
+            this.compressionType = compressionType;
+            this.rpcOptions = rpcOptions;
+            return this.manager;
+        }
     }
 }

--- a/ingester-protocol/src/test/java/io/greptime/options/GreptimeOptionsTest.java
+++ b/ingester-protocol/src/test/java/io/greptime/options/GreptimeOptionsTest.java
@@ -22,6 +22,7 @@ import io.greptime.limit.LimitedPolicy;
 import io.greptime.models.AuthInfo;
 import io.greptime.rpc.RpcOptions;
 import io.greptime.rpc.TlsOptions;
+import java.io.File;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -72,8 +73,10 @@ public class GreptimeOptionsTest {
         Assert.assertEquals(database, opts.getDatabase());
         Assert.assertArrayEquals(
                 endpoints, opts.getEndpoints().stream().map(Endpoint::toString).toArray());
-        Assert.assertEquals(rpcOptions, opts.getRpcOptions());
-        Assert.assertEquals(tlsOptions, opts.getRpcOptions().getTlsOptions());
+        Assert.assertNotSame(rpcOptions, opts.getRpcOptions());
+        assertChannelOptions(rpcOptions, opts.getRpcOptions());
+        Assert.assertNull(rpcOptions.getTlsOptions());
+        Assert.assertSame(tlsOptions, opts.getRpcOptions().getTlsOptions());
 
         RouterOptions routerOptions = opts.getRouterOptions();
         Assert.assertNotNull(routerOptions);
@@ -110,6 +113,143 @@ public class GreptimeOptionsTest {
         Assert.assertNull(copied.getRpcOptions());
     }
 
+    @Test
+    public void testBulkWriteOptionsCopyHasIndependentTlsOptions() {
+        TlsOptions tlsOptions = tlsOptions("original.pem");
+        BulkWriteOptions original = new BulkWriteOptions();
+        original.setTlsOptions(tlsOptions);
+
+        BulkWriteOptions copied = original.copy();
+
+        Assert.assertNotSame(tlsOptions, copied.getTlsOptions());
+        Assert.assertEquals(
+                new File("original.pem"), copied.getTlsOptions().getRootCerts().get());
+
+        copied.getTlsOptions().setRootCerts(new File("copied.pem"));
+        Assert.assertEquals(
+                new File("original.pem"),
+                original.getTlsOptions().getRootCerts().get());
+    }
+
+    @Test
+    public void testCopyPreservesIndependentBulkWriteOptions() {
+        RpcOptions rpcOptions = RpcOptions.newDefault();
+        rpcOptions.setMaxInboundMessageSize(1024);
+        GreptimeOptions original = GreptimeOptions.newBuilder("127.0.0.1:4001", "greptime.public")
+                .rpcOptions(rpcOptions)
+                .useZeroCopyWriteInBulkWrite(true)
+                .build();
+
+        GreptimeOptions copied = original.copy();
+
+        Assert.assertSame(copied, GreptimeOptions.checkSelf(copied));
+        Assert.assertNotSame(original.getBulkWriteOptions(), copied.getBulkWriteOptions());
+        Assert.assertNotSame(
+                original.getBulkWriteOptions().getRpcOptions(),
+                copied.getBulkWriteOptions().getRpcOptions());
+        Assert.assertEquals(
+                original.getBulkWriteOptions().isUseZeroCopyWrite(),
+                copied.getBulkWriteOptions().isUseZeroCopyWrite());
+        Assert.assertEquals(
+                original.getBulkWriteOptions().getRpcOptions().getMaxInboundMessageSize(),
+                copied.getBulkWriteOptions().getRpcOptions().getMaxInboundMessageSize());
+
+        copied.getBulkWriteOptions().setUseZeroCopyWrite(false);
+        copied.getBulkWriteOptions().getRpcOptions().setMaxInboundMessageSize(2048);
+
+        Assert.assertTrue(original.getBulkWriteOptions().isUseZeroCopyWrite());
+        Assert.assertEquals(1024, original.getBulkWriteOptions().getRpcOptions().getMaxInboundMessageSize());
+    }
+
+    @Test
+    public void testExplicitNullTlsOverridesRpcTlsRegardlessOfSetterOrder() {
+        RpcOptions rpcOptionsSetLast = rpcOptionsWithTls();
+        GreptimeOptions tlsSetFirst = GreptimeOptions.newBuilder("127.0.0.1:4001", "greptime.public")
+                .tlsOptions(null)
+                .rpcOptions(rpcOptionsSetLast)
+                .build();
+
+        RpcOptions rpcOptionsSetFirst = rpcOptionsWithTls();
+        GreptimeOptions tlsSetLast = GreptimeOptions.newBuilder("127.0.0.1:4001", "greptime.public")
+                .rpcOptions(rpcOptionsSetFirst)
+                .tlsOptions(null)
+                .build();
+
+        assertTlsCleared(tlsSetFirst);
+        assertTlsCleared(tlsSetLast);
+    }
+
+    @Test
+    public void testRpcTlsPreservedWhenTlsOptionsNotConfigured() {
+        RpcOptions rpcOptions = rpcOptionsWithTls();
+
+        GreptimeOptions opts = GreptimeOptions.newBuilder("127.0.0.1:4001", "greptime.public")
+                .rpcOptions(rpcOptions)
+                .build();
+
+        Assert.assertSame(rpcOptions, opts.getRpcOptions());
+        Assert.assertSame(rpcOptions.getTlsOptions(), opts.getRpcOptions().getTlsOptions());
+        Assert.assertNotSame(
+                rpcOptions.getTlsOptions(),
+                opts.getBulkWriteOptions().getRpcOptions().getTlsOptions());
+        Assert.assertEquals(
+                rpcOptions.getTlsOptions().getRootCerts(),
+                opts.getBulkWriteOptions().getRpcOptions().getTlsOptions().getRootCerts());
+    }
+
+    @Test
+    public void testExplicitTlsOverridesWithoutMutatingInputOrPreviousOptions() {
+        RpcOptions rpcOptions = rpcOptionsWithTls();
+        TlsOptions originalTlsOptions = rpcOptions.getTlsOptions();
+        GreptimeOptions.Builder builder =
+                GreptimeOptions.newBuilder("127.0.0.1:4001", "greptime.public").rpcOptions(rpcOptions);
+        GreptimeOptions previous = builder.build();
+        TlsOptions explicitTlsOptions = tlsOptions("explicit.pem");
+
+        GreptimeOptions opts = builder.tlsOptions(explicitTlsOptions).build();
+
+        Assert.assertSame(rpcOptions, previous.getRpcOptions());
+        Assert.assertSame(originalTlsOptions, rpcOptions.getTlsOptions());
+        Assert.assertSame(originalTlsOptions, previous.getRpcOptions().getTlsOptions());
+        Assert.assertNotSame(rpcOptions, opts.getRpcOptions());
+        Assert.assertSame(explicitTlsOptions, opts.getRpcOptions().getTlsOptions());
+        Assert.assertNotSame(
+                explicitTlsOptions, opts.getBulkWriteOptions().getRpcOptions().getTlsOptions());
+        Assert.assertEquals(
+                explicitTlsOptions.getRootCerts(),
+                opts.getBulkWriteOptions().getRpcOptions().getTlsOptions().getRootCerts());
+        Assert.assertSame(explicitTlsOptions, opts.getBulkWriteOptions().getTlsOptions());
+    }
+
+    @Test
+    public void testExplicitNullTlsDoesNotMutateInputOrPreviousOptions() {
+        RpcOptions rpcOptions = rpcOptionsWithTls();
+        TlsOptions originalTlsOptions = rpcOptions.getTlsOptions();
+        GreptimeOptions.Builder builder =
+                GreptimeOptions.newBuilder("127.0.0.1:4001", "greptime.public").rpcOptions(rpcOptions);
+        GreptimeOptions previous = builder.build();
+
+        GreptimeOptions plaintext = builder.tlsOptions(null).build();
+
+        Assert.assertSame(rpcOptions, previous.getRpcOptions());
+        Assert.assertSame(originalTlsOptions, rpcOptions.getTlsOptions());
+        Assert.assertSame(originalTlsOptions, previous.getRpcOptions().getTlsOptions());
+        Assert.assertNotSame(rpcOptions, plaintext.getRpcOptions());
+        assertTlsCleared(plaintext);
+    }
+
+    @Test
+    public void testExplicitNullTlsRemainsEffectiveWhenBuilderReused() {
+        GreptimeOptions.Builder builder = GreptimeOptions.newBuilder("127.0.0.1:4001", "greptime.public")
+                .rpcOptions(rpcOptionsWithTls())
+                .tlsOptions(null);
+
+        assertTlsCleared(builder.build());
+
+        builder.rpcOptions(rpcOptionsWithTls());
+        assertTlsCleared(builder.build());
+    }
+
     private void assertChannelOptions(RpcOptions expected, RpcOptions actual) {
         Assert.assertEquals(expected.getMaxInboundMessageSize(), actual.getMaxInboundMessageSize());
         Assert.assertEquals(expected.getFlowControlWindow(), actual.getFlowControlWindow());
@@ -117,6 +257,24 @@ public class GreptimeOptionsTest {
         Assert.assertEquals(expected.getKeepAliveTimeSeconds(), actual.getKeepAliveTimeSeconds());
         Assert.assertEquals(expected.getKeepAliveTimeoutSeconds(), actual.getKeepAliveTimeoutSeconds());
         Assert.assertEquals(expected.isKeepAliveWithoutCalls(), actual.isKeepAliveWithoutCalls());
+    }
+
+    private RpcOptions rpcOptionsWithTls() {
+        RpcOptions rpcOptions = RpcOptions.newDefault();
+        rpcOptions.setTlsOptions(tlsOptions("rpc.pem"));
+        return rpcOptions;
+    }
+
+    private TlsOptions tlsOptions(String rootCerts) {
+        TlsOptions tlsOptions = new TlsOptions();
+        tlsOptions.setRootCerts(new File(rootCerts));
+        return tlsOptions;
+    }
+
+    private void assertTlsCleared(GreptimeOptions opts) {
+        Assert.assertNull(opts.getRpcOptions().getTlsOptions());
+        Assert.assertNull(opts.getBulkWriteOptions().getRpcOptions().getTlsOptions());
+        Assert.assertNull(opts.getBulkWriteOptions().getTlsOptions());
     }
 
     private Router<Void, Endpoint> createTestRouter() {

--- a/ingester-protocol/src/test/java/io/greptime/options/GreptimeOptionsTest.java
+++ b/ingester-protocol/src/test/java/io/greptime/options/GreptimeOptionsTest.java
@@ -39,6 +39,12 @@ public class GreptimeOptionsTest {
         String[] endpoints = {"127.0.0.1:4001"};
         Executor asyncPool = command -> System.out.println("asyncPool");
         RpcOptions rpcOptions = RpcOptions.newDefault();
+        rpcOptions.setMaxInboundMessageSize(1024);
+        rpcOptions.setFlowControlWindow(2048);
+        rpcOptions.setIdleTimeoutSeconds(30);
+        rpcOptions.setKeepAliveTimeSeconds(40);
+        rpcOptions.setKeepAliveTimeoutSeconds(5);
+        rpcOptions.setKeepAliveWithoutCalls(true);
         int writeMaxRetries = 2;
         int maxInFlightWritePoints = 9990;
         LimitedPolicy limitedPolicy = new LimitedPolicy.DiscardPolicy();
@@ -87,6 +93,30 @@ public class GreptimeOptionsTest {
         Assert.assertEquals(
                 defaultStreamMaxWritePointsPerSecond, writeOptions.getDefaultStreamMaxWritePointsPerSecond());
         Assert.assertEquals(authInfo, writeOptions.getAuthInfo());
+
+        BulkWriteOptions bulkWriteOptions = opts.getBulkWriteOptions();
+        Assert.assertNotSame(rpcOptions, bulkWriteOptions.getRpcOptions());
+        assertChannelOptions(rpcOptions, bulkWriteOptions.getRpcOptions());
+
+        BulkWriteOptions copiedBulkWriteOptions = bulkWriteOptions.copy();
+        Assert.assertNotSame(bulkWriteOptions.getRpcOptions(), copiedBulkWriteOptions.getRpcOptions());
+        assertChannelOptions(bulkWriteOptions.getRpcOptions(), copiedBulkWriteOptions.getRpcOptions());
+    }
+
+    @Test
+    public void testBulkWriteOptionsCopyWithoutRpcOptions() {
+        BulkWriteOptions copied = new BulkWriteOptions().copy();
+
+        Assert.assertNull(copied.getRpcOptions());
+    }
+
+    private void assertChannelOptions(RpcOptions expected, RpcOptions actual) {
+        Assert.assertEquals(expected.getMaxInboundMessageSize(), actual.getMaxInboundMessageSize());
+        Assert.assertEquals(expected.getFlowControlWindow(), actual.getFlowControlWindow());
+        Assert.assertEquals(expected.getIdleTimeoutSeconds(), actual.getIdleTimeoutSeconds());
+        Assert.assertEquals(expected.getKeepAliveTimeSeconds(), actual.getKeepAliveTimeSeconds());
+        Assert.assertEquals(expected.getKeepAliveTimeoutSeconds(), actual.getKeepAliveTimeoutSeconds());
+        Assert.assertEquals(expected.isKeepAliveWithoutCalls(), actual.isKeepAliveWithoutCalls());
     }
 
     private Router<Void, Endpoint> createTestRouter() {

--- a/ingester-rpc/src/main/java/io/greptime/rpc/RpcOptions.java
+++ b/ingester-rpc/src/main/java/io/greptime/rpc/RpcOptions.java
@@ -259,7 +259,9 @@ public class RpcOptions implements Copiable<RpcOptions> {
         opts.blockOnLimit = this.blockOnLimit;
         opts.logOnLimitChange = this.logOnLimitChange;
         opts.enableMetricInterceptor = this.enableMetricInterceptor;
-        opts.tlsOptions = this.tlsOptions;
+        if (this.tlsOptions != null) {
+            opts.tlsOptions = this.tlsOptions.copy();
+        }
         return opts;
     }
 

--- a/ingester-rpc/src/main/java/io/greptime/rpc/RpcOptions.java
+++ b/ingester-rpc/src/main/java/io/greptime/rpc/RpcOptions.java
@@ -45,12 +45,12 @@ public class RpcOptions implements Copiable<RpcOptions> {
      */
     private long idleTimeoutSeconds = TimeUnit.MINUTES.toSeconds(5);
 
-    // --- keep-alive options: default will disable keep-alive
+    // --- keep-alive options: default sends a ping after 60 seconds without read activity while an RPC is outstanding
 
     /**
      * Sets the time without read activity before sending a keep-alive ping.
      */
-    private long keepAliveTimeSeconds = Long.MAX_VALUE;
+    private long keepAliveTimeSeconds = 60;
 
     /**
      * Sets the time waiting for read activity after sending a keep-alive ping.
@@ -65,7 +65,7 @@ public class RpcOptions implements Copiable<RpcOptions> {
      */
     private boolean keepAliveWithoutCalls = false;
 
-    // --- keep-alive options: default will disable keep-alive
+    // --- limiter options
 
     private LimitKind limitKind = LimitKind.None;
 

--- a/ingester-rpc/src/test/java/io/greptime/rpc/RpcOptionsTest.java
+++ b/ingester-rpc/src/test/java/io/greptime/rpc/RpcOptionsTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.greptime.rpc;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RpcOptionsTest {
+    @Test
+    public void newDefaultShouldUseKeepAliveDefaultsTest() {
+        RpcOptions options = RpcOptions.newDefault();
+
+        Assert.assertEquals(60, options.getKeepAliveTimeSeconds());
+        Assert.assertEquals(3, options.getKeepAliveTimeoutSeconds());
+        Assert.assertFalse(options.isKeepAliveWithoutCalls());
+    }
+}

--- a/ingester-rpc/src/test/java/io/greptime/rpc/RpcOptionsTest.java
+++ b/ingester-rpc/src/test/java/io/greptime/rpc/RpcOptionsTest.java
@@ -16,6 +16,7 @@
 
 package io.greptime.rpc;
 
+import java.io.File;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -27,5 +28,24 @@ public class RpcOptionsTest {
         Assert.assertEquals(60, options.getKeepAliveTimeSeconds());
         Assert.assertEquals(3, options.getKeepAliveTimeoutSeconds());
         Assert.assertFalse(options.isKeepAliveWithoutCalls());
+    }
+
+    @Test
+    public void copyShouldHaveIndependentTlsOptions() {
+        TlsOptions tlsOptions = new TlsOptions();
+        tlsOptions.setRootCerts(new File("original.pem"));
+        RpcOptions original = RpcOptions.newDefault();
+        original.setTlsOptions(tlsOptions);
+
+        RpcOptions copied = original.copy();
+
+        Assert.assertNotSame(tlsOptions, copied.getTlsOptions());
+        Assert.assertEquals(
+                new File("original.pem"), copied.getTlsOptions().getRootCerts().get());
+
+        copied.getTlsOptions().setRootCerts(new File("copied.pem"));
+        Assert.assertEquals(
+                new File("original.pem"),
+                original.getTlsOptions().getRootCerts().get());
     }
 }


### PR DESCRIPTION
## Summary
- enable a 60-second gRPC keepalive default
- apply channel-related RpcOptions to both Regular API and BulkStreamWriter
- preserve legacy Bulk APIs and harden channel/allocator cleanup on construction failures
- update configuration docs and add regression coverage

## Test Plan
- [x] `mvn -pl ingester-rpc,ingester-bulk-protocol,ingester-protocol -am test -DskipITs`
- [x] `mvn spotless:check`
- [x] `git diff --check origin/main...HEAD`