### PR TITLE
fix!: bound bulk write waits and cancel timed-out streams

### DIFF
--- a/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteManager.java
+++ b/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteManager.java
@@ -215,8 +215,9 @@ public class BulkWriteManager implements AutoCloseable {
             FlightDescriptor descriptor,
             PutListener metadataListener,
             long maxRequestsInFlight,
+            long timeoutMs,
             CallOption... options) {
-        return this.flightClient.startPut(descriptor, metadataListener, maxRequestsInFlight, options);
+        return this.flightClient.startPut(descriptor, metadataListener, maxRequestsInFlight, timeoutMs, options);
     }
 
     DictionaryProvider newDefaultDictionaryProvider() {

--- a/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteService.java
+++ b/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteService.java
@@ -190,6 +190,7 @@ public class BulkWriteService implements AutoCloseable {
             LOG.debug("Sending data to server [id={}]", id);
             this.listener.putNext(metadataBuf);
             metadataBuf = null; // Ownership transfers to the Flight writer.
+            future.scheduleTimeout();
 
             int inFlightCount = this.metadataListener.numInFlight();
             LOG.debug("Data sent successfully [id={}], in-flight requests: {}", id, inFlightCount);
@@ -500,8 +501,6 @@ public class BulkWriteService implements AutoCloseable {
                     LOG.debug("Put operation succeeded [id={}], affected rows: {}", id, r);
                 }
             });
-
-            future.scheduleTimeout();
 
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Attached future [id={}], current in-flight count: {}", id, this.futuresInFlight.size());

--- a/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteService.java
+++ b/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteService.java
@@ -251,7 +251,14 @@ public class BulkWriteService implements AutoCloseable {
             this.listener.completed();
         } catch (RuntimeException e) {
             if (this.metadataListener.isCompletedExceptionally()) {
-                this.metadataListener.getResult();
+                try {
+                    this.metadataListener.getResult();
+                } catch (RuntimeException terminalFailure) {
+                    if (terminalFailure != e) {
+                        terminalFailure.addSuppressed(e);
+                    }
+                    throw terminalFailure;
+                }
             }
             throw e;
         }
@@ -302,6 +309,7 @@ public class BulkWriteService implements AutoCloseable {
         AutoCloseables.close(this.root, this.manager);
     }
 
+    // May run on the shared timeout-scheduler thread, so it must never block.
     void abort(Throwable failure) {
         this.metadataListener.onError(failure);
         try {

--- a/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteService.java
+++ b/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteService.java
@@ -32,7 +32,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.arrow.flight.BulkFlightClient.ClientStreamListener;
 import org.apache.arrow.flight.BulkFlightClient.PutListener;
 import org.apache.arrow.flight.CallOption;
+import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightDescriptor;
+import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.flight.PutResult;
 import org.apache.arrow.flight.grpc.StatusUtils;
 import org.apache.arrow.memory.ArrowBuf;
@@ -91,7 +93,7 @@ public class BulkWriteService implements AutoCloseable {
         this.allocator = allocator;
         this.root = manager.createSchemaRoot(schema);
         this.metadataListener = new AsyncPutListener();
-        this.listener = manager.startPut(descriptor, this.metadataListener, maxRequestsInFlight, options);
+        this.listener = manager.startPut(descriptor, this.metadataListener, maxRequestsInFlight, timeoutMs, options);
         this.tableName = diagnosticName(descriptor);
         this.timeoutMs = timeoutMs;
     }
@@ -167,6 +169,11 @@ public class BulkWriteService implements AutoCloseable {
         // Create future with timeout and attach to listener
         IdentifiableCompletableFuture future =
                 new IdentifiableCompletableFuture(id, this.timeoutMs, this.tableName, totalRowCount, LOG);
+        future.whenComplete((r, t) -> {
+            if (t instanceof TimeoutCompletableFuture.FutureDeadlineExceededException) {
+                abort(newTimeoutFailure("Timed out waiting for a bulk write response", t));
+            }
+        });
         ArrowBuf metadataBuf = null;
         Throwable putFailure = null;
         try {
@@ -246,13 +253,50 @@ public class BulkWriteService implements AutoCloseable {
      */
     public void waitServerCompleted() {
         LOG.info("Waiting for server to complete processing");
-        this.listener.getResult();
+        try {
+            this.metadataListener.getResult(this.timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            FlightRuntimeException timeout = newTimeoutFailure("Timed out waiting for bulk stream completion", e);
+            abort(timeout);
+            throw timeout;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            FlightRuntimeException interrupted = CallStatus.CANCELLED
+                    .withDescription("Interrupted while waiting for bulk stream completion")
+                    .withCause(e)
+                    .toRuntimeException();
+            abort(interrupted);
+            throw interrupted;
+        } catch (ExecutionException e) {
+            throw StatusUtils.fromThrowable(e.getCause());
+        }
     }
 
     @Override
     public void close() throws Exception {
         LOG.info("Closing BulkWriteService resources");
+        if (!this.metadataListener.isDone()) {
+            abort(CallStatus.CANCELLED
+                    .withDescription("Bulk write stream closed before completion")
+                    .toRuntimeException());
+        }
         AutoCloseables.close(this.root, this.manager);
+    }
+
+    void abort(Throwable failure) {
+        this.metadataListener.onError(failure);
+        try {
+            this.listener.cancel("Bulk write stream aborted", failure);
+        } catch (RuntimeException | Error cancelFailure) {
+            failure.addSuppressed(cancelFailure);
+        }
+    }
+
+    private static FlightRuntimeException newTimeoutFailure(String description, Throwable cause) {
+        return CallStatus.TIMED_OUT
+                .withDescription(description)
+                .withCause(cause)
+                .toRuntimeException();
     }
 
     private long nextId() {
@@ -539,11 +583,20 @@ public class BulkWriteService implements AutoCloseable {
             return this.completed.isCompletedExceptionally();
         }
 
+        boolean isDone() {
+            return this.completed.isDone();
+        }
+
+        void getResult(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            this.completed.get(timeout, unit);
+        }
+
         @Override
         public void getResult() {
             try {
                 this.completed.get();
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw StatusUtils.fromThrowable(e);
             } catch (ExecutionException e) {
                 throw StatusUtils.fromThrowable(e.getCause());

--- a/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteService.java
+++ b/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteService.java
@@ -243,6 +243,9 @@ public class BulkWriteService implements AutoCloseable {
      */
     public void completed() {
         LOG.info("Completing bulk write operation, signaling end of transmission");
+        if (this.metadataListener.isCompletedExceptionally()) {
+            this.metadataListener.getResult();
+        }
         this.listener.completed();
     }
 
@@ -268,7 +271,9 @@ public class BulkWriteService implements AutoCloseable {
             abort(interrupted);
             throw interrupted;
         } catch (ExecutionException e) {
-            throw StatusUtils.fromThrowable(e.getCause());
+            FlightRuntimeException failure = StatusUtils.fromThrowable(e.getCause());
+            abort(failure);
+            throw failure;
         }
     }
 

--- a/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteService.java
+++ b/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteService.java
@@ -246,7 +246,14 @@ public class BulkWriteService implements AutoCloseable {
         if (this.metadataListener.isCompletedExceptionally()) {
             this.metadataListener.getResult();
         }
-        this.listener.completed();
+        try {
+            this.listener.completed();
+        } catch (RuntimeException e) {
+            if (this.metadataListener.isCompletedExceptionally()) {
+                this.metadataListener.getResult();
+            }
+            throw e;
+        }
     }
 
     /**
@@ -280,10 +287,16 @@ public class BulkWriteService implements AutoCloseable {
     @Override
     public void close() throws Exception {
         LOG.info("Closing BulkWriteService resources");
+        FlightRuntimeException failure = CallStatus.CANCELLED
+                .withDescription("Bulk write stream closed before completion")
+                .toRuntimeException();
         if (!this.metadataListener.isDone()) {
-            abort(CallStatus.CANCELLED
-                    .withDescription("Bulk write stream closed before completion")
-                    .toRuntimeException());
+            this.metadataListener.onError(failure);
+        }
+        try {
+            this.listener.cancel("Bulk write stream closed", failure);
+        } catch (RuntimeException | Error cancelFailure) {
+            failure.addSuppressed(cancelFailure);
         }
         AutoCloseables.close(this.root, this.manager);
     }

--- a/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteService.java
+++ b/ingester-bulk-protocol/src/main/java/io/greptime/BulkWriteService.java
@@ -305,6 +305,7 @@ public class BulkWriteService implements AutoCloseable {
             this.listener.cancel("Bulk write stream closed", failure);
         } catch (RuntimeException | Error cancelFailure) {
             failure.addSuppressed(cancelFailure);
+            LOG.warn("Failed to cancel the Flight call while closing the bulk write stream", cancelFailure);
         }
         AutoCloseables.close(this.root, this.manager);
     }

--- a/ingester-bulk-protocol/src/main/java/org/apache/arrow/flight/BulkFlightClient.java
+++ b/ingester-bulk-protocol/src/main/java/org/apache/arrow/flight/BulkFlightClient.java
@@ -393,8 +393,10 @@ public class BulkFlightClient implements AutoCloseable {
                     }
 
                     try {
-                        this.onStreamReadyHandler.await(
-                                Math.min(remainingNanos, TimeUnit.MILLISECONDS.toNanos(10)), TimeUnit.NANOSECONDS);
+                        if (this.onStreamReadyHandler.await(
+                                Math.min(remainingNanos, TimeUnit.MILLISECONDS.toNanos(10)), TimeUnit.NANOSECONDS)) {
+                            break;
+                        }
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         FlightRuntimeException interrupted = CallStatus.CANCELLED
@@ -494,11 +496,15 @@ public class BulkFlightClient implements AutoCloseable {
         Throwable failure = null;
         try {
             if (!channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)) {
-                channel.shutdownNow();
+                forceShutdownAndAwait();
             }
         } catch (InterruptedException closeFailure) {
-            channel.shutdownNow();
             failure = closeFailure;
+            try {
+                forceShutdownAndAwait();
+            } catch (InterruptedException | RuntimeException | Error forceFailure) {
+                closeFailure.addSuppressed(forceFailure);
+            }
             Thread.currentThread().interrupt();
         } catch (RuntimeException | Error closeFailure) {
             failure = closeFailure;
@@ -522,6 +528,11 @@ public class BulkFlightClient implements AutoCloseable {
         if (failure instanceof Error) {
             throw (Error) failure;
         }
+    }
+
+    private void forceShutdownAndAwait() throws InterruptedException {
+        channel.shutdownNow();
+        channel.awaitTermination(1, TimeUnit.SECONDS);
     }
 
     /**

--- a/ingester-bulk-protocol/src/main/java/org/apache/arrow/flight/BulkFlightClient.java
+++ b/ingester-bulk-protocol/src/main/java/org/apache/arrow/flight/BulkFlightClient.java
@@ -173,6 +173,25 @@ public class BulkFlightClient implements AutoCloseable {
             PutListener metadataListener,
             long maxRequestsInFlight,
             CallOption... options) {
+        return startPut(descriptor, metadataListener, maxRequestsInFlight, Long.MAX_VALUE, options);
+    }
+
+    /**
+     * Create a DoPut stream with a bounded wait for outbound stream readiness.
+     *
+     * @param descriptor The descriptor for the stream.
+     * @param metadataListener A handler for metadata messages from the server.
+     * @param maxRequestsInFlight The maximum number of in-flight requests.
+     * @param timeoutMs The maximum time to wait for stream readiness.
+     * @param options RPC-layer hints for this call.
+     * @return A client stream listener that controls the upload.
+     */
+    public ClientStreamListener startPut(
+            FlightDescriptor descriptor,
+            PutListener metadataListener,
+            long maxRequestsInFlight,
+            long timeoutMs,
+            CallOption... options) {
         Preconditions.checkNotNull(descriptor, "descriptor must not be null");
         Preconditions.checkNotNull(metadataListener, "metadataListener must not be null");
 
@@ -190,6 +209,7 @@ public class BulkFlightClient implements AutoCloseable {
                     metadataListener::isCompletedExceptionally,
                     metadataListener::getResult,
                     onStreamReadyHandler,
+                    timeoutMs,
                     this.compressionType);
         } catch (StatusRuntimeException sre) {
             throw StatusUtils.fromGrpcRuntimeException(sre);
@@ -200,7 +220,7 @@ public class BulkFlightClient implements AutoCloseable {
         return new MapDictionaryProvider();
     }
 
-    private static class OnStreamReadyHandler implements Runnable {
+    static class OnStreamReadyHandler implements Runnable {
         private final int maxRequestsInFlight;
         private final Semaphore semaphore;
 
@@ -278,6 +298,8 @@ public class BulkFlightClient implements AutoCloseable {
         private final BooleanSupplier isCompletedExceptionally;
         private final Runnable getResult;
         private final OnStreamReadyHandler onStreamReadyHandler;
+        private final ClientCallStreamObserver<ArrowMessage> observer;
+        private final long timeoutNanos;
         private final ArrowCompressionType compressionType;
 
         /**
@@ -297,6 +319,7 @@ public class BulkFlightClient implements AutoCloseable {
                 BooleanSupplier isCompletedExceptionally,
                 Runnable getResult,
                 OnStreamReadyHandler onStreamReadyHandler,
+                long timeoutMs,
                 ArrowCompressionType compressionType) {
             super(descriptor, observer);
             Preconditions.checkNotNull(descriptor, "descriptor must be provided");
@@ -307,6 +330,8 @@ public class BulkFlightClient implements AutoCloseable {
             this.isCompletedExceptionally = isCompletedExceptionally;
             this.getResult = getResult;
             this.onStreamReadyHandler = onStreamReadyHandler;
+            this.observer = observer;
+            this.timeoutNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMs);
             this.compressionType = compressionType;
             this.unloader = null;
         }
@@ -349,25 +374,35 @@ public class BulkFlightClient implements AutoCloseable {
         protected void waitUntilStreamReady() {
             Timer.Context timerCtx = MetricsUtil.timer("bulk_flight_client.wait_until_stream_ready")
                     .time();
+            long startNanos = System.nanoTime();
             try {
-                // Check isCancelled as well to avoid inadvertently blocking forever
-                // (so long as PutListener properly implements it)
-                while (!super.responseObserver.isReady() && !this.isCancelled.getAsBoolean()) {
-                    if (this.isCompletedExceptionally.getAsBoolean()) {
+                while (!super.responseObserver.isReady()) {
+                    if (this.isCancelled.getAsBoolean() || this.isCompletedExceptionally.getAsBoolean()) {
                         // Will throw the error immediately
                         getResult();
                     }
 
-                    // If the stream is not ready, wait for a short time to avoid busy waiting
-                    // This helps reduce CPU usage while still being responsive
+                    long elapsedNanos = System.nanoTime() - startNanos;
+                    long remainingNanos = this.timeoutNanos - elapsedNanos;
+                    if (remainingNanos <= 0) {
+                        FlightRuntimeException timeout = CallStatus.TIMED_OUT
+                                .withDescription("Timed out waiting for the bulk write stream to become ready")
+                                .toRuntimeException();
+                        cancel("Bulk write stream readiness timed out", timeout);
+                        throw timeout;
+                    }
+
                     try {
-                        if (this.onStreamReadyHandler.await(10, TimeUnit.MILLISECONDS)) {
-                            // Allow some in-flight requests to be sent
-                            break;
-                        }
+                        this.onStreamReadyHandler.await(
+                                Math.min(remainingNanos, TimeUnit.MILLISECONDS.toNanos(10)), TimeUnit.NANOSECONDS);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
-                        throw new RuntimeException("Interrupted while waiting for stream to be ready", e);
+                        FlightRuntimeException interrupted = CallStatus.CANCELLED
+                                .withDescription("Interrupted while waiting for the bulk write stream to become ready")
+                                .withCause(e)
+                                .toRuntimeException();
+                        cancel("Bulk write stream readiness interrupted", interrupted);
+                        throw interrupted;
                     }
                 }
             } finally {
@@ -378,6 +413,11 @@ public class BulkFlightClient implements AutoCloseable {
         @Override
         public void getResult() {
             this.getResult.run();
+        }
+
+        @Override
+        public void cancel(String message, Throwable cause) {
+            this.observer.cancel(message, cause);
         }
     }
 
@@ -391,6 +431,16 @@ public class BulkFlightClient implements AutoCloseable {
          * happened during the upload.
          */
         void getResult();
+
+        /**
+         * Cancel the underlying Flight call.
+         *
+         * @param message cancellation description
+         * @param cause cancellation cause
+         */
+        default void cancel(String message, Throwable cause) {
+            error(cause);
+        }
     }
 
     /**
@@ -443,8 +493,11 @@ public class BulkFlightClient implements AutoCloseable {
     public void close() throws InterruptedException {
         Throwable failure = null;
         try {
-            channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+            if (!channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)) {
+                channel.shutdownNow();
+            }
         } catch (InterruptedException closeFailure) {
+            channel.shutdownNow();
             failure = closeFailure;
             Thread.currentThread().interrupt();
         } catch (RuntimeException | Error closeFailure) {

--- a/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteServiceTest.java
+++ b/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteServiceTest.java
@@ -207,6 +207,32 @@ public class BulkWriteServiceTest {
     }
 
     @Test
+    public void testCompletedReportsFailureFromConcurrentAbort() throws Exception {
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            ServiceFixture fixture = newServiceFixture(allocator);
+            FlightRuntimeException timeout =
+                    CallStatus.TIMED_OUT.withDescription("message timed out").toRuntimeException();
+            Mockito.doAnswer(invocation -> {
+                        fixture.metadataListener.onError(timeout);
+                        throw new IllegalStateException("call was cancelled");
+                    })
+                    .when(fixture.stream)
+                    .completed();
+
+            FlightRuntimeException failure = null;
+            try {
+                fixture.service.completed();
+                Assert.fail("Expected completion to report the concurrent abort failure");
+            } catch (FlightRuntimeException e) {
+                failure = e;
+            }
+
+            Assert.assertSame(timeout, failure);
+            fixture.service.close();
+        }
+    }
+
+    @Test
     public void testServerFailureCancelsStream() throws Exception {
         try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
             ServiceFixture fixture = newServiceFixture(allocator);
@@ -258,7 +284,7 @@ public class BulkWriteServiceTest {
 
             Assert.assertTrue(fixture.metadataListener.isCompletedExceptionally());
             Mockito.verify(fixture.stream)
-                    .cancel(Mockito.eq("Bulk write stream aborted"), Mockito.isA(FlightRuntimeException.class));
+                    .cancel(Mockito.eq("Bulk write stream closed"), Mockito.isA(FlightRuntimeException.class));
         }
     }
 
@@ -300,6 +326,8 @@ public class BulkWriteServiceTest {
                 Assert.assertEquals(0, fixture.metadataListener.numInFlight());
                 Assert.assertTrue(fixture.metadataListener.isCompletedExceptionally());
             }
+            Mockito.verify(fixture.stream)
+                    .cancel(Mockito.eq("Bulk write stream closed"), Mockito.isA(FlightRuntimeException.class));
         }
     }
 

--- a/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteServiceTest.java
+++ b/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteServiceTest.java
@@ -276,6 +276,32 @@ public class BulkWriteServiceTest {
     }
 
     @Test
+    public void testResponseTimeoutStartsAfterSendCompletes() throws Exception {
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            ServiceFixture fixture = newServiceFixture(allocator, 10L);
+            Mockito.doAnswer(invocation -> {
+                        ArrowBuf metadata = invocation.getArgument(0);
+                        metadata.close();
+                        Thread.sleep(50L);
+                        Assert.assertFalse(fixture.metadataListener.isDone());
+                        Mockito.verify(fixture.stream, Mockito.never()).cancel(Mockito.anyString(), Mockito.any());
+                        return null;
+                    })
+                    .when(fixture.stream)
+                    .putNext(Mockito.any());
+
+            try (BulkWriteService service = fixture.service) {
+                BulkWriteService.PutStage stage = service.putNext();
+
+                Assert.assertTrue(
+                        getFailure(stage.future()) instanceof TimeoutCompletableFuture.FutureDeadlineExceededException);
+                Mockito.verify(fixture.stream, Mockito.timeout(1000))
+                        .cancel(Mockito.eq("Bulk write stream aborted"), Mockito.isA(FlightRuntimeException.class));
+            }
+        }
+    }
+
+    @Test
     public void testCloseCancelsActiveStream() throws Exception {
         try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
             ServiceFixture fixture = newServiceFixture(allocator);

--- a/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteServiceTest.java
+++ b/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteServiceTest.java
@@ -16,6 +16,7 @@
 
 package io.greptime;
 
+import io.greptime.common.TimeoutCompletableFuture;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -154,6 +155,78 @@ public class BulkWriteServiceTest {
     }
 
     @Test
+    public void testWaitServerCompletedUsesConfiguredTimeout() throws Exception {
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            ServiceFixture fixture = newServiceFixture(allocator, 10L);
+            Mockito.doAnswer(invocation -> {
+                        fixture.metadataListener.getResult();
+                        return null;
+                    })
+                    .when(fixture.stream)
+                    .getResult();
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            Future<Throwable> wait = executor.submit(() -> {
+                try {
+                    fixture.service.waitServerCompleted();
+                    return null;
+                } catch (Throwable t) {
+                    return t;
+                }
+            });
+
+            try {
+                Throwable failure = wait.get(1, TimeUnit.SECONDS);
+                Assert.assertTrue(failure instanceof FlightRuntimeException);
+                Assert.assertEquals(
+                        FlightStatusCode.TIMED_OUT,
+                        ((FlightRuntimeException) failure).status().code());
+                Mockito.verify(fixture.stream, Mockito.timeout(1000))
+                        .cancel(Mockito.eq("Bulk write stream aborted"), Mockito.isA(FlightRuntimeException.class));
+            } finally {
+                wait.cancel(true);
+                executor.shutdownNow();
+                fixture.service.close();
+            }
+        }
+    }
+
+    @Test
+    public void testMessageTimeoutCancelsStream() throws Exception {
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            ServiceFixture fixture = newServiceFixture(allocator, 10L);
+            Mockito.doAnswer(invocation -> {
+                        ArrowBuf metadata = invocation.getArgument(0);
+                        metadata.close();
+                        return null;
+                    })
+                    .when(fixture.stream)
+                    .putNext(Mockito.any());
+            try (BulkWriteService service = fixture.service) {
+                BulkWriteService.PutStage stage = service.putNext();
+
+                Assert.assertTrue(
+                        getFailure(stage.future()) instanceof TimeoutCompletableFuture.FutureDeadlineExceededException);
+                Assert.assertTrue(fixture.metadataListener.isCompletedExceptionally());
+                Mockito.verify(fixture.stream, Mockito.timeout(1000))
+                        .cancel(Mockito.eq("Bulk write stream aborted"), Mockito.isA(FlightRuntimeException.class));
+            }
+        }
+    }
+
+    @Test
+    public void testCloseCancelsActiveStream() throws Exception {
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            ServiceFixture fixture = newServiceFixture(allocator);
+
+            fixture.service.close();
+
+            Assert.assertTrue(fixture.metadataListener.isCompletedExceptionally());
+            Mockito.verify(fixture.stream)
+                    .cancel(Mockito.eq("Bulk write stream aborted"), Mockito.isA(FlightRuntimeException.class));
+        }
+    }
+
+    @Test
     public void testPutNextDoesNotSendAfterStreamTermination() throws Exception {
         try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
             ServiceFixture fixture = newServiceFixture(allocator);
@@ -210,6 +283,7 @@ public class BulkWriteServiceTest {
                             Mockito.eq(descriptor),
                             Mockito.any(PutListener.class),
                             Mockito.eq(1L),
+                            Mockito.eq(60000L),
                             Mockito.<CallOption[]>any()))
                     .thenReturn(stream);
             Mockito.doThrow(sendFailure).when(stream).putNext(Mockito.any());
@@ -325,6 +399,10 @@ public class BulkWriteServiceTest {
     }
 
     private static ServiceFixture newServiceFixture(BufferAllocator allocator) {
+        return newServiceFixture(allocator, 60000L);
+    }
+
+    private static ServiceFixture newServiceFixture(BufferAllocator allocator, long timeoutMs) {
         BulkWriteManager manager = Mockito.mock(BulkWriteManager.class);
         ClientStreamListener stream = Mockito.mock(ClientStreamListener.class);
         Schema schema = new Schema(Collections.emptyList());
@@ -337,10 +415,11 @@ public class BulkWriteServiceTest {
                         Mockito.eq(descriptor),
                         metadataListener.capture(),
                         Mockito.eq(1L),
+                        Mockito.eq(timeoutMs),
                         Mockito.<CallOption[]>any()))
                 .thenReturn(stream);
 
-        BulkWriteService service = new BulkWriteService(manager, allocator, schema, descriptor, 60000L, 1);
+        BulkWriteService service = new BulkWriteService(manager, allocator, schema, descriptor, timeoutMs, 1);
         return new ServiceFixture(service, stream, (BulkWriteService.AsyncPutListener) metadataListener.getValue());
     }
 

--- a/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteServiceTest.java
+++ b/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteServiceTest.java
@@ -228,6 +228,8 @@ public class BulkWriteServiceTest {
             }
 
             Assert.assertSame(timeout, failure);
+            Assert.assertEquals(1, failure.getSuppressed().length);
+            Assert.assertTrue(failure.getSuppressed()[0] instanceof IllegalStateException);
             fixture.service.close();
         }
     }

--- a/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteServiceTest.java
+++ b/ingester-bulk-protocol/src/test/java/io/greptime/BulkWriteServiceTest.java
@@ -158,12 +158,6 @@ public class BulkWriteServiceTest {
     public void testWaitServerCompletedUsesConfiguredTimeout() throws Exception {
         try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
             ServiceFixture fixture = newServiceFixture(allocator, 10L);
-            Mockito.doAnswer(invocation -> {
-                        fixture.metadataListener.getResult();
-                        return null;
-                    })
-                    .when(fixture.stream)
-                    .getResult();
             ExecutorService executor = Executors.newSingleThreadExecutor();
             Future<Throwable> wait = executor.submit(() -> {
                 try {
@@ -187,6 +181,48 @@ public class BulkWriteServiceTest {
                 executor.shutdownNow();
                 fixture.service.close();
             }
+        }
+    }
+
+    @Test
+    public void testCompletedAfterAbortReportsOriginalFailure() throws Exception {
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            ServiceFixture fixture = newServiceFixture(allocator);
+            FlightRuntimeException timeout =
+                    CallStatus.TIMED_OUT.withDescription("message timed out").toRuntimeException();
+            fixture.service.abort(timeout);
+
+            FlightRuntimeException failure = null;
+            try {
+                fixture.service.completed();
+                Assert.fail("Expected completion to report the abort failure");
+            } catch (FlightRuntimeException e) {
+                failure = e;
+            }
+
+            Assert.assertEquals(FlightStatusCode.TIMED_OUT, failure.status().code());
+            Mockito.verify(fixture.stream, Mockito.never()).completed();
+            fixture.service.close();
+        }
+    }
+
+    @Test
+    public void testServerFailureCancelsStream() throws Exception {
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            ServiceFixture fixture = newServiceFixture(allocator);
+            fixture.metadataListener.onError(CallStatus.UNAVAILABLE.toRuntimeException());
+
+            FlightRuntimeException failure = null;
+            try {
+                fixture.service.waitServerCompleted();
+                Assert.fail("Expected server failure");
+            } catch (FlightRuntimeException e) {
+                failure = e;
+            }
+
+            Assert.assertEquals(FlightStatusCode.UNAVAILABLE, failure.status().code());
+            Mockito.verify(fixture.stream).cancel(Mockito.eq("Bulk write stream aborted"), Mockito.same(failure));
+            fixture.service.close();
         }
     }
 

--- a/ingester-bulk-protocol/src/test/java/org/apache/arrow/flight/BulkFlightClientTest.java
+++ b/ingester-bulk-protocol/src/test/java/org/apache/arrow/flight/BulkFlightClientTest.java
@@ -197,6 +197,26 @@ public class BulkFlightClientTest {
     }
 
     @Test
+    public void testReadinessPermitAllowsPipelinedWrite() {
+        @SuppressWarnings("unchecked")
+        ClientCallStreamObserver<ArrowMessage> observer = Mockito.mock(ClientCallStreamObserver.class);
+        Mockito.when(observer.isReady()).thenReturn(false);
+        BulkFlightClient.PutObserver putObserver = new BulkFlightClient.PutObserver(
+                FlightDescriptor.path("metrics"),
+                observer,
+                () -> false,
+                () -> false,
+                () -> {},
+                new BulkFlightClient.OnStreamReadyHandler(1),
+                10L,
+                ArrowCompressionType.None);
+
+        putObserver.waitUntilStreamReady();
+
+        Mockito.verify(observer, Mockito.never()).cancel(Mockito.anyString(), Mockito.any());
+    }
+
+    @Test
     public void testCloseForcesChannelShutdownAfterGracePeriod() throws Exception {
         BufferAllocator parentAllocator = Mockito.mock(BufferAllocator.class);
         BufferAllocator childAllocator = Mockito.mock(BufferAllocator.class);
@@ -212,6 +232,7 @@ public class BulkFlightClientTest {
         client.close();
 
         Mockito.verify(channel).shutdownNow();
+        Mockito.verify(channel).awaitTermination(1, TimeUnit.SECONDS);
         Mockito.verify(childAllocator).close();
     }
 
@@ -240,6 +261,7 @@ public class BulkFlightClientTest {
 
             Assert.assertSame(interruption, failure);
             Mockito.verify(channel).shutdownNow();
+            Mockito.verify(channel).awaitTermination(1, TimeUnit.SECONDS);
             Mockito.verify(childAllocator).close();
             Assert.assertTrue(Thread.currentThread().isInterrupted());
         } finally {

--- a/ingester-bulk-protocol/src/test/java/org/apache/arrow/flight/BulkFlightClientTest.java
+++ b/ingester-bulk-protocol/src/test/java/org/apache/arrow/flight/BulkFlightClientTest.java
@@ -22,6 +22,7 @@ import io.greptime.rpc.TlsOptions;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.ClientCallStreamObserver;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -169,6 +170,52 @@ public class BulkFlightClientTest {
     }
 
     @Test
+    public void testReadinessTimeoutCancelsFlightCall() {
+        @SuppressWarnings("unchecked")
+        ClientCallStreamObserver<ArrowMessage> observer = Mockito.mock(ClientCallStreamObserver.class);
+        Mockito.when(observer.isReady()).thenReturn(false);
+        BulkFlightClient.PutObserver putObserver = new BulkFlightClient.PutObserver(
+                FlightDescriptor.path("metrics"),
+                observer,
+                () -> false,
+                () -> false,
+                () -> {},
+                new BulkFlightClient.OnStreamReadyHandler(0),
+                10L,
+                ArrowCompressionType.None);
+
+        FlightRuntimeException failure = null;
+        try {
+            putObserver.waitUntilStreamReady();
+            Assert.fail("Expected readiness timeout");
+        } catch (FlightRuntimeException e) {
+            failure = e;
+        }
+
+        Assert.assertEquals(FlightStatusCode.TIMED_OUT, failure.status().code());
+        Mockito.verify(observer).cancel(Mockito.eq("Bulk write stream readiness timed out"), Mockito.same(failure));
+    }
+
+    @Test
+    public void testCloseForcesChannelShutdownAfterGracePeriod() throws Exception {
+        BufferAllocator parentAllocator = Mockito.mock(BufferAllocator.class);
+        BufferAllocator childAllocator = Mockito.mock(BufferAllocator.class);
+        Mockito.when(parentAllocator.newChildAllocator("bulk-flight-client", 0, Long.MAX_VALUE))
+                .thenReturn(childAllocator);
+        ManagedChannel channel = Mockito.mock(ManagedChannel.class);
+        Mockito.when(channel.shutdown()).thenReturn(channel);
+        Mockito.when(channel.awaitTermination(5, TimeUnit.SECONDS)).thenReturn(false);
+        Mockito.when(channel.shutdownNow()).thenReturn(channel);
+        BulkFlightClient client =
+                new BulkFlightClient(parentAllocator, channel, Collections.emptyList(), ArrowCompressionType.None);
+
+        client.close();
+
+        Mockito.verify(channel).shutdownNow();
+        Mockito.verify(childAllocator).close();
+    }
+
+    @Test
     public void testCloseClosesChildAllocatorWhenChannelShutdownIsInterrupted() throws Exception {
         Thread.interrupted();
         try {
@@ -192,6 +239,7 @@ public class BulkFlightClientTest {
             }
 
             Assert.assertSame(interruption, failure);
+            Mockito.verify(channel).shutdownNow();
             Mockito.verify(childAllocator).close();
             Assert.assertTrue(Thread.currentThread().isInterrupted());
         } finally {

--- a/ingester-protocol/src/main/java/io/greptime/BulkStreamWriter.java
+++ b/ingester-protocol/src/main/java/io/greptime/BulkStreamWriter.java
@@ -85,7 +85,8 @@ public interface BulkStreamWriter extends AutoCloseable {
      * Completes the bulk write operation by signaling the end of transmission
      * and waits for the server to finish processing the data. This method
      * must be called to ensure all data is properly written and to receive
-     * any errors that may have occurred during the operation.
+     * any errors that may have occurred during the operation. The wait is
+     * bounded by the configured bulk write timeout.
      *
      * @throws Exception if an error occurs
      */

--- a/ingester-protocol/src/main/java/io/greptime/BulkStreamWriter.java
+++ b/ingester-protocol/src/main/java/io/greptime/BulkStreamWriter.java
@@ -34,6 +34,9 @@ import java.util.concurrent.CompletableFuture;
  * errors are properly reported. Additionally, you should call the {@code close()} method to ensure all
  * related resources are properly released, though this happens automatically when using try-with-resources.
  *
+ * <p>A timeout, interruption, or limiter abort permanently terminates this writer and causes all subsequent
+ * operations to fail. To continue writing, close this writer and create a new one.
+ *
  * <p>Example usage:
  * <pre>{@code
  * try (BulkStreamWriter bulkStreamWriter = greptimeDB.bulkStreamWriter(schema)) { // auto close in try-with-resources

--- a/ingester-protocol/src/main/java/io/greptime/BulkStreamWriter.java
+++ b/ingester-protocol/src/main/java/io/greptime/BulkStreamWriter.java
@@ -79,6 +79,10 @@ public interface BulkStreamWriter extends AutoCloseable {
     /**
      * Writes current table data to the stream.
      *
+     * <p>When the max in-flight limit is reached, this method blocks waiting for a slot, bounded
+     * by the configured bulk write timeout. It no longer blocks indefinitely: if the wait times
+     * out, this method throws and the writer becomes terminal (see the class-level documentation).
+     *
      * @return a future that completes with the number of rows affected
      * @throws Exception if an error occurs
      */

--- a/ingester-protocol/src/main/java/io/greptime/BulkWrite.java
+++ b/ingester-protocol/src/main/java/io/greptime/BulkWrite.java
@@ -25,7 +25,9 @@ import io.greptime.rpc.Context;
 public interface BulkWrite {
 
     /**
-     * The default timeout in milliseconds for each bulk write operation.
+     * The default timeout in milliseconds bounding each blocking bulk write wait
+     * (in-flight slot acquisition, stream readiness, per-message response, stream completion).
+     * It is not a single end-to-end operation timeout.
      */
     long DEFAULT_TIMEOUT_MS_PER_MESSAGE = 60000;
 

--- a/ingester-protocol/src/main/java/io/greptime/BulkWrite.java
+++ b/ingester-protocol/src/main/java/io/greptime/BulkWrite.java
@@ -104,6 +104,10 @@ public interface BulkWrite {
              * Set the timeout in milliseconds for acquiring an in-flight slot, waiting for stream
              * readiness, receiving a message response, and completing the stream.
              *
+             * <p>The timeout bounds each of these waits independently, so a single blocking call
+             * (e.g. {@code writeNext()}) may take up to a small multiple of this value in the
+             * worst case. Size caller-side deadlines accordingly.
+             *
              * @param timeoutMsPerMessage the timeout in milliseconds
              * @return this builder
              */

--- a/ingester-protocol/src/main/java/io/greptime/BulkWrite.java
+++ b/ingester-protocol/src/main/java/io/greptime/BulkWrite.java
@@ -25,7 +25,7 @@ import io.greptime.rpc.Context;
 public interface BulkWrite {
 
     /**
-     * The default timeout in milliseconds for each message.
+     * The default timeout in milliseconds for each bulk write operation.
      */
     long DEFAULT_TIMEOUT_MS_PER_MESSAGE = 60000;
 
@@ -101,7 +101,8 @@ public interface BulkWrite {
             }
 
             /**
-             * Set the timeout in milliseconds for each message.
+             * Set the timeout in milliseconds for acquiring an in-flight slot, waiting for stream
+             * readiness, receiving a message response, and completing the stream.
              *
              * @param timeoutMsPerMessage the timeout in milliseconds
              * @return this builder
@@ -155,7 +156,7 @@ public interface BulkWrite {
      * @param schema the schema of the table
      * @param allocatorInitReservation the initial space reservation (obtained from this allocator)
      * @param allocatorMaxAllocation the maximum amount of space the new child allocator can allocate
-     * @param timeoutMsPerMessage the timeout in milliseconds for each message
+     * @param timeoutMsPerMessage the timeout in milliseconds for each blocking bulk write operation
      * @param maxRequestsInFlight the max in-flight requests in the stream
      * @param ctx invoke context
      * @return a bulk stream writer instance

--- a/ingester-protocol/src/main/java/io/greptime/BulkWriteClient.java
+++ b/ingester-protocol/src/main/java/io/greptime/BulkWriteClient.java
@@ -45,7 +45,9 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightCallHeaders;
+import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.flight.HeaderCallOption;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.slf4j.Logger;
@@ -290,6 +292,15 @@ public class BulkWriteClient implements BulkWrite, Health, Lifecycle<BulkWriteOp
                     return future;
                 });
             } catch (LimitedException e) {
+                if (e.getCause() instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    FlightRuntimeException interrupted = CallStatus.CANCELLED
+                            .withDescription("Interrupted while waiting for a bulk write in-flight slot")
+                            .withCause(e.getCause())
+                            .toRuntimeException();
+                    this.writer.abort(interrupted);
+                    throw interrupted;
+                }
                 this.writer.abort(e);
                 throw e;
             }

--- a/ingester-protocol/src/main/java/io/greptime/BulkWriteClient.java
+++ b/ingester-protocol/src/main/java/io/greptime/BulkWriteClient.java
@@ -27,6 +27,7 @@ import io.greptime.common.util.Ensures;
 import io.greptime.common.util.MetricExecutor;
 import io.greptime.common.util.MetricsUtil;
 import io.greptime.common.util.SerializingExecutor;
+import io.greptime.errors.LimitedException;
 import io.greptime.limit.AbstractLimiter;
 import io.greptime.limit.LimitedPolicy;
 import io.greptime.models.ArrowHelper;
@@ -154,7 +155,7 @@ public class BulkWriteClient implements BulkWrite, Health, Lifecycle<BulkWriteOp
         if (this.opts.isUseZeroCopyWrite()) {
             writer.tryUseZeroCopyWrite();
         }
-        return new DefaultBulkStreamWriter(writer, schema, maxRequestsInFlight);
+        return new DefaultBulkStreamWriter(writer, schema, maxRequestsInFlight, timeoutMsPerMessage);
     }
 
     BulkWriteManager createBulkWriteManager(
@@ -220,10 +221,11 @@ public class BulkWriteClient implements BulkWrite, Health, Lifecycle<BulkWriteOp
         private final TableSchema tableSchema;
         private final AtomicReference<Table.TableBufferRoot> current = new AtomicReference<>();
 
-        public DefaultBulkStreamWriter(BulkWriteService writer, TableSchema tableSchema, int maxRequestsInFlight) {
+        public DefaultBulkStreamWriter(
+                BulkWriteService writer, TableSchema tableSchema, int maxRequestsInFlight, long timeoutMsPerMessage) {
             this.writer = writer;
             this.tableSchema = tableSchema;
-            this.pipelineWriteLimiter = new BulkWriteLimiter(maxRequestsInFlight);
+            this.pipelineWriteLimiter = new BulkWriteLimiter(maxRequestsInFlight, timeoutMsPerMessage);
         }
 
         @Override
@@ -258,33 +260,39 @@ public class BulkWriteClient implements BulkWrite, Health, Lifecycle<BulkWriteOp
             }
 
             AtomicReference<BulkWriteService.PutStage> putStage = new AtomicReference<>();
-            CompletableFuture<Integer> result = this.pipelineWriteLimiter.acquireAndDo(null, () -> {
-                Clock clock = Clock.defaultClock();
+            CompletableFuture<Integer> result;
+            try {
+                result = this.pipelineWriteLimiter.acquireAndDo(null, () -> {
+                    Clock clock = Clock.defaultClock();
 
-                long startPut = clock.getTick();
-                BulkWriteService.PutStage stage = this.writer.putNext();
-                putStage.set(stage);
-                InnerMetricHelper.prepareTime().update(clock.duration(startPut), TimeUnit.MILLISECONDS);
+                    long startPut = clock.getTick();
+                    BulkWriteService.PutStage stage = this.writer.putNext();
+                    putStage.set(stage);
+                    InnerMetricHelper.prepareTime().update(clock.duration(startPut), TimeUnit.MILLISECONDS);
 
-                long startCall = clock.getTick();
-                int inFlight = stage.numInFlight();
-                CompletableFuture<Integer> future = stage.future();
-                future.whenComplete((r, t) -> {
-                    long duration = clock.duration(startCall);
-                    InnerMetricHelper.putTime().update(duration, TimeUnit.MILLISECONDS);
-                    if (Util.isBulkWriteLogging()) {
-                        LOG.info(
-                                "Bulk write completed - table={}, rows={}, bytes={}, duration={}ms, in-flight={} requests",
-                                tableName,
-                                rows,
-                                bytes,
-                                duration,
-                                inFlight);
-                    }
+                    long startCall = clock.getTick();
+                    int inFlight = stage.numInFlight();
+                    CompletableFuture<Integer> future = stage.future();
+                    future.whenComplete((r, t) -> {
+                        long duration = clock.duration(startCall);
+                        InnerMetricHelper.putTime().update(duration, TimeUnit.MILLISECONDS);
+                        if (Util.isBulkWriteLogging()) {
+                            LOG.info(
+                                    "Bulk write completed - table={}, rows={}, bytes={}, duration={}ms, in-flight={} requests",
+                                    tableName,
+                                    rows,
+                                    bytes,
+                                    duration,
+                                    inFlight);
+                        }
+                    });
+
+                    return future;
                 });
-
-                return future;
-            });
+            } catch (LimitedException e) {
+                this.writer.abort(e);
+                throw e;
+            }
             return new TimeoutLoggingFuture(result, putStage.get());
         }
 
@@ -334,12 +342,15 @@ public class BulkWriteClient implements BulkWrite, Health, Lifecycle<BulkWriteOp
 
     /**
      * Limiter that controls the number of concurrent bulk write operations.
-     * Uses a blocking policy to ensure the maximum number of in-flight requests is not exceeded.
+     * Uses a bounded blocking policy to ensure the maximum number of in-flight requests is not exceeded.
      */
     static class BulkWriteLimiter extends AbstractLimiter<Void, Integer> {
 
-        public BulkWriteLimiter(int maxInFlight) {
-            super(maxInFlight, new LimitedPolicy.BlockingPolicy(), "bulk_write_limiter_acquire");
+        public BulkWriteLimiter(int maxInFlight, long timeoutMs) {
+            super(
+                    maxInFlight,
+                    new LimitedPolicy.AbortOnBlockingTimeoutPolicy(timeoutMs, TimeUnit.MILLISECONDS),
+                    "bulk_write_limiter_acquire");
         }
 
         @Override
@@ -349,7 +360,7 @@ public class BulkWriteClient implements BulkWrite, Health, Lifecycle<BulkWriteOp
 
         @Override
         public Integer rejected(Void in, RejectedState state) {
-            throw new IllegalStateException("A blocking limiter should never get here");
+            throw new IllegalStateException("A timeout-aborting limiter should never get here");
         }
     }
 }

--- a/ingester-protocol/src/main/java/io/greptime/limit/InFlightLimiter.java
+++ b/ingester-protocol/src/main/java/io/greptime/limit/InFlightLimiter.java
@@ -44,6 +44,7 @@ public class InFlightLimiter implements Limiter {
         try {
             this.semaphore.acquire(permits);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new LimitedException(e);
         } finally {
             this.acquireTimer.update(Clock.defaultClock().duration(startCall), TimeUnit.MILLISECONDS);
@@ -56,6 +57,7 @@ public class InFlightLimiter implements Limiter {
         try {
             return this.semaphore.tryAcquire(permits, timeout, unit);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new LimitedException(e);
         } finally {
             this.acquireTimer.update(Clock.defaultClock().duration(startCall), TimeUnit.MILLISECONDS);

--- a/ingester-protocol/src/test/java/io/greptime/BulkWriteClientTest.java
+++ b/ingester-protocol/src/test/java/io/greptime/BulkWriteClientTest.java
@@ -17,6 +17,7 @@
 package io.greptime;
 
 import io.greptime.common.Endpoint;
+import io.greptime.errors.LimitedException;
 import io.greptime.models.DataType;
 import io.greptime.models.TableSchema;
 import io.greptime.options.BulkWriteOptions;
@@ -105,6 +106,29 @@ public class BulkWriteClientTest {
         }
 
         Mockito.verify(stage).logTimeout(timeout, 1, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testBulkWriteLimiterUsesConfiguredTimeout() {
+        BulkWriteClient.BulkWriteLimiter limiter = new BulkWriteClient.BulkWriteLimiter(1, 10L);
+        CompletableFuture<Integer> first = new CompletableFuture<>();
+        limiter.acquireAndDo(null, () -> first);
+
+        long startNanos = System.nanoTime();
+        try {
+            limiter.acquireAndDo(null, () -> CompletableFuture.completedFuture(1));
+            Assert.fail("Expected limiter timeout");
+        } catch (LimitedException expected) {
+            long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+            Assert.assertTrue("Limiter timeout took too long: " + elapsedMillis + "ms", elapsedMillis < 1000L);
+        } finally {
+            first.complete(1);
+        }
+
+        Assert.assertEquals(
+                Integer.valueOf(1),
+                limiter.acquireAndDo(null, () -> CompletableFuture.completedFuture(1))
+                        .join());
     }
 
     private static class CapturingBulkWriteClient extends BulkWriteClient {

--- a/ingester-protocol/src/test/java/io/greptime/BulkWriteClientTest.java
+++ b/ingester-protocol/src/test/java/io/greptime/BulkWriteClientTest.java
@@ -18,6 +18,7 @@ package io.greptime;
 
 import io.greptime.common.Endpoint;
 import io.greptime.errors.LimitedException;
+import io.greptime.models.ArrowHelper;
 import io.greptime.models.DataType;
 import io.greptime.models.TableSchema;
 import io.greptime.options.BulkWriteOptions;
@@ -26,8 +27,16 @@ import io.greptime.rpc.RpcOptions;
 import io.greptime.rpc.TlsOptions;
 import java.io.File;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.flight.FlightStatusCode;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -129,6 +138,55 @@ public class BulkWriteClientTest {
                 Integer.valueOf(1),
                 limiter.acquireAndDo(null, () -> CompletableFuture.completedFuture(1))
                         .join());
+    }
+
+    @Test
+    public void testInterruptedLimiterWaitCancelsStream() throws Exception {
+        Thread.interrupted();
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            TableSchema schema = TableSchema.newBuilder("test_table")
+                    .addField("value", DataType.Int64)
+                    .build();
+            try (VectorSchemaRoot root = VectorSchemaRoot.create(ArrowHelper.createSchema(schema), allocator)) {
+                BulkWriteService service = Mockito.mock(BulkWriteService.class);
+                Mockito.when(service.getRoot()).thenReturn(root);
+                CompletableFuture<Integer> first = new CompletableFuture<>();
+                Mockito.when(service.putNext()).thenReturn(new BulkWriteService.PutStage(first, 1));
+                BulkWriteClient.DefaultBulkStreamWriter writer =
+                        new BulkWriteClient.DefaultBulkStreamWriter(service, schema, 1, 60_000L);
+                writer.tableBufferRoot(8);
+                writer.writeNext();
+
+                CountDownLatch started = new CountDownLatch(1);
+                AtomicReference<Throwable> failure = new AtomicReference<>();
+                AtomicBoolean interrupted = new AtomicBoolean();
+                Thread thread = new Thread(() -> {
+                    try {
+                        writer.tableBufferRoot(8);
+                        started.countDown();
+                        writer.writeNext();
+                    } catch (Throwable t) {
+                        failure.set(t);
+                        interrupted.set(Thread.currentThread().isInterrupted());
+                    }
+                });
+                thread.start();
+                Assert.assertTrue(started.await(1, TimeUnit.SECONDS));
+                thread.interrupt();
+                thread.join(TimeUnit.SECONDS.toMillis(1));
+                first.complete(1);
+
+                Assert.assertFalse("Limiter thread did not stop after interruption", thread.isAlive());
+                Assert.assertTrue(failure.get() instanceof FlightRuntimeException);
+                Assert.assertEquals(
+                        FlightStatusCode.CANCELLED,
+                        ((FlightRuntimeException) failure.get()).status().code());
+                Assert.assertTrue(interrupted.get());
+                Mockito.verify(service).abort(Mockito.same(failure.get()));
+            }
+        } finally {
+            Thread.interrupted();
+        }
     }
 
     private static class CapturingBulkWriteClient extends BulkWriteClient {

--- a/ingester-protocol/src/test/java/io/greptime/WriteLimitTest.java
+++ b/ingester-protocol/src/test/java/io/greptime/WriteLimitTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Assert;
 import org.junit.Test;
@@ -90,12 +91,14 @@ public class WriteLimitTest {
 
         CountDownLatch acquiring = new CountDownLatch(1);
         AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
         final Thread t = new Thread(() -> {
             acquiring.countDown();
             try {
                 limiter.acquireAndDo(rows, this::emptyOk);
             } catch (Throwable err) {
                 failure.set(err);
+                interrupted.set(Thread.currentThread().isInterrupted());
             }
         });
         t.start();
@@ -107,6 +110,7 @@ public class WriteLimitTest {
         Assert.assertFalse("Limiter thread did not stop after interruption", t.isAlive());
         Assert.assertTrue(failure.get() instanceof LimitedException);
         Assert.assertTrue(failure.get().getCause() instanceof InterruptedException);
+        Assert.assertTrue(interrupted.get());
     }
 
     @Test


### PR DESCRIPTION
## What changed

- apply `timeoutMsPerMessage` to bulk limiter acquisition, Flight stream readiness, per-message responses, and final stream completion
- cancel the underlying Flight/DoPut call when those operations time out, are interrupted, or the active stream is closed early
- force channel shutdown after the graceful shutdown window expires
- add regression tests for each bounded wait and cancellation path

## Why

[flink-connector-greptimedb#21](https://github.com/GreptimeTeam/flink-connector-greptimedb/pull/21) adds a connector-side executor wrapper because the SDK can otherwise keep a Flink task blocked indefinitely. The wrapper is a useful stopgap, but interrupting the wrapper thread does not guarantee that the SDK's DoPut call has stopped.

This change puts the timeout and cancellation ownership in the SDK. It preserves the existing public `startPut` signature and reuses the existing bulk timeout setting instead of introducing another configuration value.

A timed-out stream is terminal and must be closed/recreated by the caller. Automatic replay/recovery and route-resolution timeouts are intentionally outside this PR.

## Validation

- `mvn spotless:check`
- Java 8: `mvn test`
- focused timeout/cancellation tests for `BulkWriteService`, `BulkFlightClient`, and `BulkWriteClient`
- `git diff --check`

## Breaking behavior change

`writeNext()` previously blocked indefinitely when `maxRequestsInFlight` slots were exhausted. It now fails after `timeoutMsPerMessage` and the stream becomes terminal (it must be closed and recreated). Callers that relied on unbounded blocking as flow control should size `timeoutMsPerMessage` accordingly. Note that the timeout bounds each blocking wait (slot acquisition, stream readiness, per-message response, completion) independently, so a single call may wait up to a small multiple of the configured value in the worst case.
