### PR TITLE
feat: support Flight auto-create table metadata and hint

### DIFF
--- a/ingester-protocol/src/main/java/io/greptime/models/ArrowHelper.java
+++ b/ingester-protocol/src/main/java/io/greptime/models/ArrowHelper.java
@@ -22,8 +22,10 @@ import io.greptime.rpc.Context;
 import io.greptime.v1.Common;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
@@ -61,12 +63,34 @@ import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 /**
  * Helper class for Arrow schema creation.
  */
 public class ArrowHelper {
+
+    /**
+     * The Arrow field metadata key that marks a column as the time index.
+     * The value must be "true". Recognized by the GreptimeDB server when
+     * auto-creating tables for bulk insert requests.
+     */
+    public static final String TIME_INDEX_METADATA_KEY = "greptime:time_index";
+
+    /**
+     * The Arrow field metadata key that carries the semantic type of a column.
+     * The value must be "tag" or "field". Recognized by the GreptimeDB server
+     * when auto-creating tables for bulk insert requests.
+     */
+    public static final String SEMANTIC_TYPE_METADATA_KEY = "greptime:semantic_type";
+
+    /**
+     * The Arrow field metadata key that carries the GreptimeDB extended data type
+     * of a column, e.g. "Json". Recognized by the GreptimeDB server when
+     * auto-creating tables for bulk insert requests.
+     */
+    public static final String DATA_TYPE_METADATA_KEY = "greptime:type";
 
     /**
      * Get the Arrow compression type from the context.
@@ -89,6 +113,13 @@ public class ArrowHelper {
 
     /**
      * Create an Arrow schema from a table schema.
+     * <p>
+     * The semantic types of the columns are encoded as Arrow field metadata so that
+     * the GreptimeDB server can auto-create the table for bulk insert requests:
+     * the timestamp column is marked with `greptime:time_index=true` and is
+     * non-nullable, tag and field columns carry `greptime:semantic_type=tag` and
+     * `greptime:semantic_type=field` respectively, and JSON columns carry
+     * `greptime:type=Json`.
      *
      * @param tableSchema the table schema
      * @return the Arrow schema
@@ -101,6 +132,7 @@ public class ArrowHelper {
         List<Field> fields = new ArrayList<>(columnCount);
 
         List<String> columnNames = tableSchema.getColumnNames();
+        List<Common.SemanticType> semanticTypes = tableSchema.getSemanticTypes();
         List<Common.ColumnDataType> dataTypes = tableSchema.getDataTypes();
         List<Common.ColumnDataTypeExtension> dataTypeExtensions = tableSchema.getDataTypeExtensions();
 
@@ -108,8 +140,29 @@ public class ArrowHelper {
             String name = columnNames.get(i);
             ArrowType type = convertToArrowType(dataTypes.get(i), dataTypeExtensions.get(i));
 
-            Field field = Field.nullable(name, type);
-            fields.add(field);
+            Map<String, String> metadata = new HashMap<>(2);
+            boolean nullable = true;
+            switch (semanticTypes.get(i)) {
+                case TIMESTAMP:
+                    metadata.put(TIME_INDEX_METADATA_KEY, "true");
+                    // The time index column is never null in GreptimeDB, and the server
+                    // requires it to be non-nullable when auto-creating the table.
+                    nullable = false;
+                    break;
+                case TAG:
+                    metadata.put(SEMANTIC_TYPE_METADATA_KEY, "tag");
+                    break;
+                case FIELD:
+                    metadata.put(SEMANTIC_TYPE_METADATA_KEY, "field");
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unsupported semantic type: " + semanticTypes.get(i));
+            }
+            if (dataTypes.get(i) == Common.ColumnDataType.JSON) {
+                metadata.put(DATA_TYPE_METADATA_KEY, "Json");
+            }
+
+            fields.add(new Field(name, new FieldType(nullable, type, null, metadata), null));
         }
 
         return new Schema(fields);

--- a/ingester-protocol/src/main/java/io/greptime/models/ArrowHelper.java
+++ b/ingester-protocol/src/main/java/io/greptime/models/ArrowHelper.java
@@ -72,16 +72,9 @@ import org.apache.arrow.vector.types.pojo.Schema;
 public class ArrowHelper {
 
     /**
-     * The Arrow field metadata key that marks a column as the time index.
-     * The value must be "true". Recognized by the GreptimeDB server when
-     * auto-creating tables for bulk insert requests.
-     */
-    public static final String TIME_INDEX_METADATA_KEY = "greptime:time_index";
-
-    /**
      * The Arrow field metadata key that carries the semantic type of a column.
-     * The value must be "tag" or "field". Recognized by the GreptimeDB server
-     * when auto-creating tables for bulk insert requests.
+     * The value must be "tag", "field" or "timestamp". Recognized by the
+     * GreptimeDB server when auto-creating tables for bulk insert requests.
      */
     public static final String SEMANTIC_TYPE_METADATA_KEY = "greptime:semantic_type";
 
@@ -116,10 +109,9 @@ public class ArrowHelper {
      * <p>
      * The semantic types of the columns are encoded as Arrow field metadata so that
      * the GreptimeDB server can auto-create the table for bulk insert requests:
-     * the timestamp column is marked with `greptime:time_index=true` and is
-     * non-nullable, tag and field columns carry `greptime:semantic_type=tag` and
-     * `greptime:semantic_type=field` respectively, and JSON columns carry
-     * `greptime:type=Json`.
+     * each column carries {@code greptime:semantic_type} with value {@code tag},
+     * {@code field} or {@code timestamp}, the timestamp (time index) column is
+     * non-nullable, and JSON columns additionally carry {@code greptime:type=Json}.
      *
      * @param tableSchema the table schema
      * @return the Arrow schema
@@ -144,7 +136,7 @@ public class ArrowHelper {
             boolean nullable = true;
             switch (semanticTypes.get(i)) {
                 case TIMESTAMP:
-                    metadata.put(TIME_INDEX_METADATA_KEY, "true");
+                    metadata.put(SEMANTIC_TYPE_METADATA_KEY, "timestamp");
                     // The time index column is never null in GreptimeDB, and the server
                     // requires it to be non-nullable when auto-creating the table.
                     nullable = false;

--- a/ingester-protocol/src/main/java/io/greptime/models/ArrowHelper.java
+++ b/ingester-protocol/src/main/java/io/greptime/models/ArrowHelper.java
@@ -132,7 +132,8 @@ public class ArrowHelper {
             String name = columnNames.get(i);
             ArrowType type = convertToArrowType(dataTypes.get(i), dataTypeExtensions.get(i));
 
-            Map<String, String> metadata = new HashMap<>(2);
+            // JSON columns carry a second metadata entry (greptime:type=Json)
+            Map<String, String> metadata = new HashMap<>(4);
             boolean nullable = true;
             switch (semanticTypes.get(i)) {
                 case TIMESTAMP:

--- a/ingester-protocol/src/test/java/io/greptime/models/ArrowHelperTest.java
+++ b/ingester-protocol/src/test/java/io/greptime/models/ArrowHelperTest.java
@@ -166,19 +166,16 @@ public class ArrowHelperTest {
         Field tagField = schema.getFields().get(0);
         Assert.assertTrue(tagField.isNullable());
         Assert.assertEquals("tag", tagField.getMetadata().get(ArrowHelper.SEMANTIC_TYPE_METADATA_KEY));
-        Assert.assertFalse(tagField.getMetadata().containsKey(ArrowHelper.TIME_INDEX_METADATA_KEY));
         Assert.assertFalse(tagField.getMetadata().containsKey(ArrowHelper.DATA_TYPE_METADATA_KEY));
 
         Field tsField = schema.getFields().get(1);
         Assert.assertFalse(tsField.isNullable());
-        Assert.assertEquals("true", tsField.getMetadata().get(ArrowHelper.TIME_INDEX_METADATA_KEY));
-        Assert.assertFalse(tsField.getMetadata().containsKey(ArrowHelper.SEMANTIC_TYPE_METADATA_KEY));
+        Assert.assertEquals("timestamp", tsField.getMetadata().get(ArrowHelper.SEMANTIC_TYPE_METADATA_KEY));
         Assert.assertFalse(tsField.getMetadata().containsKey(ArrowHelper.DATA_TYPE_METADATA_KEY));
 
         Field field1 = schema.getFields().get(2);
         Assert.assertTrue(field1.isNullable());
         Assert.assertEquals("field", field1.getMetadata().get(ArrowHelper.SEMANTIC_TYPE_METADATA_KEY));
-        Assert.assertFalse(field1.getMetadata().containsKey(ArrowHelper.TIME_INDEX_METADATA_KEY));
         Assert.assertFalse(field1.getMetadata().containsKey(ArrowHelper.DATA_TYPE_METADATA_KEY));
 
         Field jsonField = schema.getFields().get(3);

--- a/ingester-protocol/src/test/java/io/greptime/models/ArrowHelperTest.java
+++ b/ingester-protocol/src/test/java/io/greptime/models/ArrowHelperTest.java
@@ -20,6 +20,7 @@ import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Assert;
 import org.junit.Test;
@@ -149,5 +150,40 @@ public class ArrowHelperTest {
         Assert.assertEquals(
                 new ArrowType.Binary().getTypeID(),
                 schema.getFields().get(22).getType().getTypeID());
+    }
+
+    @Test
+    public void testCreateSchemaWithSemanticTypeMetadata() {
+        TableSchema tableSchema = TableSchema.newBuilder("my_table")
+                .addTag("tag1", DataType.String)
+                .addTimestamp("ts", DataType.TimestampMillisecond)
+                .addField("field1", DataType.Float64)
+                .addField("field2", DataType.Json)
+                .build();
+
+        Schema schema = ArrowHelper.createSchema(tableSchema);
+
+        Field tagField = schema.getFields().get(0);
+        Assert.assertTrue(tagField.isNullable());
+        Assert.assertEquals("tag", tagField.getMetadata().get(ArrowHelper.SEMANTIC_TYPE_METADATA_KEY));
+        Assert.assertFalse(tagField.getMetadata().containsKey(ArrowHelper.TIME_INDEX_METADATA_KEY));
+        Assert.assertFalse(tagField.getMetadata().containsKey(ArrowHelper.DATA_TYPE_METADATA_KEY));
+
+        Field tsField = schema.getFields().get(1);
+        Assert.assertFalse(tsField.isNullable());
+        Assert.assertEquals("true", tsField.getMetadata().get(ArrowHelper.TIME_INDEX_METADATA_KEY));
+        Assert.assertFalse(tsField.getMetadata().containsKey(ArrowHelper.SEMANTIC_TYPE_METADATA_KEY));
+        Assert.assertFalse(tsField.getMetadata().containsKey(ArrowHelper.DATA_TYPE_METADATA_KEY));
+
+        Field field1 = schema.getFields().get(2);
+        Assert.assertTrue(field1.isNullable());
+        Assert.assertEquals("field", field1.getMetadata().get(ArrowHelper.SEMANTIC_TYPE_METADATA_KEY));
+        Assert.assertFalse(field1.getMetadata().containsKey(ArrowHelper.TIME_INDEX_METADATA_KEY));
+        Assert.assertFalse(field1.getMetadata().containsKey(ArrowHelper.DATA_TYPE_METADATA_KEY));
+
+        Field jsonField = schema.getFields().get(3);
+        Assert.assertTrue(jsonField.isNullable());
+        Assert.assertEquals("field", jsonField.getMetadata().get(ArrowHelper.SEMANTIC_TYPE_METADATA_KEY));
+        Assert.assertEquals("Json", jsonField.getMetadata().get(ArrowHelper.DATA_TYPE_METADATA_KEY));
     }
 }

--- a/ingester-rpc/src/main/java/io/greptime/rpc/Context.java
+++ b/ingester-rpc/src/main/java/io/greptime/rpc/Context.java
@@ -92,6 +92,10 @@ public class Context {
 
     /**
      * Adds a hint to the context.
+     * <p>
+     * Repeated calls append entries rather than overwriting: calling this twice
+     * with the same key produces a hint string like {@code key=value1,key=value2},
+     * and which value takes effect is up to server-side parsing.
      *
      * @param key the key
      * @param value the value

--- a/ingester-rpc/src/main/java/io/greptime/rpc/Context.java
+++ b/ingester-rpc/src/main/java/io/greptime/rpc/Context.java
@@ -28,6 +28,8 @@ import java.util.Set;
 @SuppressWarnings({"unchecked"})
 public class Context {
 
+    private static final String AUTO_CREATE_TABLE_HINT = "auto_create_table";
+
     private final Map<String, Object> ctx = new HashMap<>();
 
     private Compression compression = Compression.None;
@@ -107,6 +109,17 @@ public class Context {
             });
         }
         return this;
+    }
+
+    /**
+     * Sets whether this request allows the server to auto-create a missing table.
+     * The server-side global auto-create-table option must also be enabled.
+     *
+     * @param enabled whether this request allows automatic table creation
+     * @return this {@link Context}
+     */
+    public Context withAutoCreateTable(boolean enabled) {
+        return withHint(AUTO_CREATE_TABLE_HINT, Boolean.toString(enabled));
     }
 
     /**

--- a/ingester-rpc/src/main/java/io/greptime/rpc/Context.java
+++ b/ingester-rpc/src/main/java/io/greptime/rpc/Context.java
@@ -117,7 +117,19 @@ public class Context {
 
     /**
      * Sets whether this request allows the server to auto-create a missing table.
-     * The server-side global auto-create-table option must also be enabled.
+     * <p>
+     * The hint travels with any write that uses this {@link Context}: it is sent
+     * on bulk writes (Flight) as well as on row-based writes, where it is carried
+     * as a gRPC header by {@code ContextToHeadersInterceptor}.
+     * <p>
+     * Note the asymmetry: {@code false} always disables auto-creation for this
+     * request, while {@code true} cannot override a server whose global
+     * auto-create-table option is disabled.
+     * <p>
+     * Like {@link #withHint}, repeated calls append instead of overwriting, so
+     * calling this twice on a reused {@link Context} yields duplicate
+     * {@code auto_create_table} hints. Use a fresh {@link Context} (or
+     * {@link #remove(String)} on the hints key) to change the value.
      *
      * @param enabled whether this request allows automatic table creation
      * @return this {@link Context}

--- a/ingester-rpc/src/test/java/io/greptime/rpc/ContextTest.java
+++ b/ingester-rpc/src/test/java/io/greptime/rpc/ContextTest.java
@@ -52,6 +52,13 @@ public class ContextTest {
     }
 
     @Test
+    public void withAutoCreateTableTest() {
+        Context context = Context.newDefault().withAutoCreateTable(false);
+
+        Assert.assertEquals("auto_create_table=false", context.getHints());
+    }
+
+    @Test
     public void getShouldReturnNullForNonExistingKeyTest() {
         Context context = Context.newDefault();
         Assert.assertNull(context.get("key"));


### PR DESCRIPTION
## What changed

Align the Java bulk (Arrow Flight) write path with the current contract in GreptimeTeam/greptimedb-enterprise#845 (server head `9b277b5b`):

- Every Arrow field carries `greptime:semantic_type` with value `tag`, `field`, or `timestamp`.
- The `timestamp` field is non-nullable and identifies the unique time index.
- JSON fields additionally carry `greptime:type=Json`, preserving the extended type during automatic table creation.
- `Context.withAutoCreateTable(boolean)` provides a typed request-level `auto_create_table` hint. It is encoded through the existing `x-greptime-hints` header path used by Flight writes.

The request hint follows server semantics: the server global auto-create option remains the upper bound; an explicit `false` disables automatic creation for that request. Existing-table schema alignment remains available regardless of this hint.

The row-based write path already sends semantic types through proto `ColumnSchema.semantic_type` and is unchanged.

## Verification

- `mvn test`
- `mvn spotless:check`
- `git diff --check`

## Related

- GreptimeTeam/greptimedb-enterprise#845